### PR TITLE
Prevent Linux from crashing on compile

### DIFF
--- a/Classes/SteamValidation.cpp
+++ b/Classes/SteamValidation.cpp
@@ -163,8 +163,10 @@ std::vector<std::string> SteamValidation::getPossibleGDPaths()
     return {
         "~/.var/app/com.valvesoftware.Steam/.steam/root/steamapps/common/Geometry Dash/",
         "~/.steam/root/steamapps/common/Geometry Dash/",
-        "~/.var/app/com.valvesoftware.Steam/data/Steam/steamapps/common/Geometry Dash\",
+        "~/.var/app/com.valvesoftware.Steam/data/Steam/steamapps/common/Geometry Dash/",
     };
+    #elif (AX_TARGET_PLATFORM == AX_PLATFORM_MAC)
+    return {"~/Library/Application Support/Steam/steamapps/common/Geometry Dash"};
     #else
     return {};
     #endif


### PR DESCRIPTION
This change allows you to compile on Linux, and fixes the mistake for the string when specifying the directory if the platform is Linux: (`\` instead of `/`)
This changes `~/.var/app/com.valvesoftware.Steam/data/Steam/steamapps/common/Geometry Dash\` to `~/.var/app/com.valvesoftware.Steam/data/Steam/steamapps/common/Geometry Dash/`.

This change also adds a new directory if the platform is Mac. Although I don't have a Mac so I cannot confirm that works, and I'm unsure whether or not GD is just a `.app` file (`Geometry Dash.app`) or a directory for Mac and the binary is there. (`Geometry Dash/`)

Let me know if there needs to be any changes.