### PR TITLE
Fix allowed chars to allow the number 0

### DIFF
--- a/Classes/TextInputNode.cpp
+++ b/Classes/TextInputNode.cpp
@@ -41,7 +41,7 @@ bool TextInputNode::onTouchBegan(Touch* touch, Event* event)
 bool TextInputNode::init(float width, float height, const char* placeholder, const char* font, int scale)
 {
 	if (!Layer::init()) return false;
-	_pAllowedChars = " abcdefghijkmlnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ123456789";
+	_pAllowedChars = " abcdefghijkmlnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
 
 	this->setContentSize({ width, height });
 	


### PR DESCRIPTION
I just noticed this when trying to type an ID in that had a 0 and it wasn't letting me, I added a 0, woah.