### PR TITLE
Fix Particle Rotation not working

### DIFF
--- a/Classes/GameObject.cpp
+++ b/Classes/GameObject.cpp
@@ -203,8 +203,8 @@ void GameObject::update()
 			_particle->setPosition(pos);
 		
 		_particle->setRotation(getRotation());
-		_particle->setScaleX(getScaleX() * isFlippedX() ? -1.f : 1.f);
-		_particle->setScaleY(getScaleY() * isFlippedY() ? -1.f : 1.f);
+		_particle->setScaleX(getScaleX() * (isFlippedX() ? -1.f : 1.f));
+		_particle->setScaleY(getScaleY() * (isFlippedY() ? -1.f : 1.f));
 		float op = getOpacity();
 		
 		if (_particle->getOpacity() != op)

--- a/Classes/PlayLayer.cpp
+++ b/Classes/PlayLayer.cpp
@@ -979,7 +979,7 @@ void PlayLayer::updateVisibility()
 					{
 						if (obj->_particle)
 						{
-							_particleBatchNode->addChild(obj->_particle);
+							addChild(obj->_particle);
 							AX_SAFE_RELEASE(obj->_particle);
 						}
 						if (obj->_glowSprite)
@@ -1088,7 +1088,7 @@ void PlayLayer::updateVisibility()
 				if (section[j]->_particle)
 				{
 					AX_SAFE_RETAIN(section[j]->_particle);
-					_particleBatchNode->removeChild(section[j]->_particle, true);
+					removeChild(section[j]->_particle, true);
 				}
 				if (section[j]->_glowSprite)
 				{
@@ -1587,7 +1587,7 @@ void PlayLayer::resetLevel()
 			if (obj->_particle)
 			{
 				AX_SAFE_RETAIN(obj->_particle);
-				_particleBatchNode->removeChild(obj->_particle, true);
+				removeChild(obj->_particle, true);
 			}
 			if (obj->_glowSprite)
 			{

--- a/Classes/PlayLayer.cpp
+++ b/Classes/PlayLayer.cpp
@@ -557,8 +557,8 @@ bool PlayLayer::init(GJGameLevel* level)
 	_main2BatchNode = ax::SpriteBatchNode::create(GameToolbox::getTextureString(_main2BatchNodeTexture), 150);
 	this->addChild(_main2BatchNode);
 
-	_particleBatchNode = ax::ParticleBatchNode::create("square.png", 30);
-	addChild(_particleBatchNode);
+	//_particleBatchNode = ax::ParticleBatchNode::create("square.png", 30);
+	//addChild(_particleBatchNode);
 
 	_mainBatchNodeTexture = _mainBatchNodeT3->getTexture()->getPath();
 	_main2BatchNodeTexture = _main2BatchNode->getTexture()->getPath();


### PR DESCRIPTION
### This change fixes particles (portals, pads, etc) from not rotating based on the sprite.

This changes the files: `GameObject.cpp` and `PlayLayer.cpp`.

The changes that may have to be looked into, is with `PlayLayer.cpp`, as the notable change I've made was to have the particle added to the layer instead of `_particleBatchNode`, as it seems to fix the issue.

The change I've made with `PlayLayer.cpp` is setting the scale properly for the particles. (By surrounding the ternary operator with parenthesis)

**The following screenshots show the result of the fix.**
![Theory of Everything 2](https://user-images.githubusercontent.com/17692105/229325801-9737968c-35e8-4837-be7c-7aa7d1394a3f.png)
![The Nightmare](https://user-images.githubusercontent.com/17692105/229325841-dad2a626-b8cd-4cbd-a9d2-34b44f3de653.png)

Let me know if there needs to be any changes.