### PR TITLE
Rewritten TextInputNode

### DIFF
--- a/Source/LevelSearchLayer.cpp
+++ b/Source/LevelSearchLayer.cpp
@@ -105,23 +105,20 @@ bool LevelSearchLayer::init()
 	menuSearch->addChild(searchProfileBtn);
 	this->addChild(menuSearch);
 
-	_searchField = TextInputNode::create(194.0f, 50.0f, GameToolbox::getTextureString("bigFont.fnt").c_str(), "Enter a level, user or id", 18);
-	_searchField->_pTextField->setAnchorPoint({ 0.0, 0.5 });
-	_searchField->_pTextField->setMaxLength(20);
-	_searchField->_pTextField->setMaxLengthEnabled(true);
-	_searchField->_pPlaceholder->setColor({ 120, 170, 240 });
-	_searchField->setPosition({ searchPos.x - 174.0f, searchPos.y - 25.0f });
+	_searchField = TextInputNode::create(194.0f, 50.0f, GameToolbox::getTextureString("bigFont.fnt").c_str(), "Enter a level, user or id", 0x18);
+	_searchField->setPosition({ searchPos.x - 174.0f, searchPos.y });
+	_searchField->setAnchorPoint({ 0.0, 0.5 });
+
+	auto sfTextField = _searchField->getTextField();
+	sfTextField->setMaxLength(20);
+	sfTextField->setMaxLengthEnabled(true);
+
+	auto sfDisplayLabel = _searchField->getDisplayedLabel();
+	sfDisplayLabel->setPositionX(0);
+	sfDisplayLabel->setAnchorPoint({ 0, 0.5 });
+
 	this->addChild(_searchField);
 
-
-	// _searchField = ui::TextField::create("Enter a level, user or id", GameToolbox::getTextureString("bigFont.fnt"), 15);
-	// _searchField->setPlaceHolderColor({ 120, 170, 240 });
-	// _searchField->setMaxLength(20);
-	// _searchField->setTextHorizontalAlignment(ax::TextHAlignment::LEFT); //not working? lol
-	// _searchField->setMaxLengthEnabled(true);
-	// _searchField->setCursorEnabled(true);
-	// _searchField->setPosition({ searchPos.x - 75.0f, searchPos.y });
-	// this->addChild(_searchField);
 
 	// Quick Search
 	Vec2 quickSearchPos{ winSize.width / 2, winSize.height / 2 + 28.0f };
@@ -312,7 +309,7 @@ bool LevelSearchLayer::init()
 
 void LevelSearchLayer::onSearch(Node* btn)
 {
-	_searchObject->_searchQuery = _searchField->_pTextField->getString();
+	_searchObject->_searchQuery = _searchField->getTextField()->getString();
 	_searchObject->_difficulty = "";
 	_searchObject->_length = "";
 	_searchObject->_screenID = SearchType::kGJSearchTypeSearch;

--- a/Source/TextInputNode.cpp
+++ b/Source/TextInputNode.cpp
@@ -321,6 +321,11 @@ std::string_view TextInputNode::getString()
 	return _textField->getString();
 }
 
+TextInputDelegate* TextInputNode::getDelegate()
+{
+	return _delegate;
+}
+
 void TextInputNode::setMaxDisplayLabelScale(float scale)
 {
 	_maxDisplayLabelScale = scale;
@@ -355,4 +360,9 @@ void TextInputNode::setString(std::string_view str)
 {
 	_textField->setString(str);
 	updateDisplayedLabel();
+}
+
+void TextInputNode::setDelegate(TextInputDelegate* delegate)
+{
+	_delegate = delegate;
 }

--- a/Source/TextInputNode.h
+++ b/Source/TextInputNode.h
@@ -3,35 +3,71 @@
 #include <axmol.h>
 #include <ui/CocosGUI.h>
 
+class TextInputDelegate;
+
 class TextInputNode : public ax::Layer
 {
 public:
-	std::string _pAllowedChars;
-	ax::ui::TextField* _pTextField;
-	ax::Label* _pPlaceholder;
+	TextInputNode();
 
-	bool _pCommandMode;
+	static TextInputNode* create(float width, float height, std::string_view font, std::string_view placeholder, int scale);
 
-	static TextInputNode* create(float width, float height, const char* font, const char* placeholder, int scale)
-	{
-		TextInputNode* pRet = new TextInputNode();
-		if (pRet->init(width, height, placeholder, font, scale))
-		{
-			pRet->autorelease();
-			return pRet;
-		}
-		else
-		{
-			delete pRet;
-			pRet = nullptr;
-			return nullptr;
-		}
-	}
+	bool init(float width, float height, std::string_view placeholder, std::string_view font, int scale);
+
+	void onTextFieldChanged();
+	void onTextFieldAttachWithIME();
+	void onTextFieldDetachWithIME();
+
+	void updateDisplayedLabel();
+	void updateDisplayedLabelScale();
+	void updateCursor();
+
+	std::string sanitizeString(std::string_view);
+
+	ax::Label* getDisplayedLabel();
+	ax::ui::TextField* getTextField();
+	float getMaxDisplayLabelScale();
+	float getPlaceholderScale();
+	std::string_view getAllowedChars();
+	std::string_view getString();
+
+	void setMaxDisplayLabelScale(float scale);
+	void setPlaceholderScale(float scale);
+	void setPlaceholderColor(ax::Color3B color);
+	void setDisplayedLabelColor(ax::Color3B color);
+	void setAllowedChars(std::string_view allowedChars);
+	void setString(std::string_view str);
 
 	bool onTouchBegan(ax::Touch* touch, ax::Event* event);
 
 	void onKeyPressed(ax::EventKeyboard::KeyCode keyCode, ax::Event* event);
 	void onKeyReleased(ax::EventKeyboard::KeyCode keyCode, ax::Event* event);
+private:
+	float _maxDisplayLabelScale;
+	float _placeholderScale;
 
-	bool init(float width, float height, const char* placeholder, const char* font, int scale);
+	std::string_view _allowedChars;
+	std::string_view _placeholderString;
+
+	std::string _previousString;
+
+	ax::Color3B _placeholderColor;
+	ax::Color3B _textColor;
+
+	bool _onCommandMode;
+
+	ax::ui::TextField* _textField;
+
+	ax::Label* _displayedLabel;
+	ax::Label* _cursor;
+
+	TextInputDelegate* _delegate;
+};
+
+class TextInputDelegate
+{
+public:
+	virtual void textChanged(TextInputNode*) {}
+	virtual void textInputOpened(TextInputNode*) {}
+	virtual void textInputClosed(TextInputNode*) {}
 };

--- a/Source/TextInputNode.h
+++ b/Source/TextInputNode.h
@@ -30,6 +30,7 @@ public:
 	float getPlaceholderScale();
 	std::string_view getAllowedChars();
 	std::string_view getString();
+	TextInputDelegate* getDelegate();
 
 	void setMaxDisplayLabelScale(float scale);
 	void setPlaceholderScale(float scale);
@@ -37,6 +38,7 @@ public:
 	void setDisplayedLabelColor(ax::Color3B color);
 	void setAllowedChars(std::string_view allowedChars);
 	void setString(std::string_view str);
+	void setDelegate(TextInputDelegate*);
 
 	bool onTouchBegan(ax::Touch* touch, ax::Event* event);
 


### PR DESCRIPTION
This changes TextInputNode to work similarly to GD.

Notable additions:
- **Added delegates**
I just guessed how it worked so it probably works differently on GD.

- **Changed how text input is displayed**
Instead of directly displaying the text field, it's contents are now mirrored on a label. The label is only added if a non-empty string is provided for the `font` parameter in the create function, which can be useful for layers that use other means to display the contents.

- **Added cursor**