### PR TITLE
Header include minimization

### DIFF
--- a/Source/AlertLayer.cpp
+++ b/Source/AlertLayer.cpp
@@ -2,6 +2,8 @@
 #include <ui/CocosGUI.h>
 #include "GameToolbox.h"
 #include "ButtonSprite.h"
+#include "2d/CCMenu.h"
+#include "MenuItemSpriteExtra.h"
 
 USING_NS_AX;
 
@@ -10,7 +12,7 @@ bool AlertLayer::init(std::string_view title, std::string_view desc, std::string
 	if (!PopupLayer::init()) 
 		return false;
 
-	auto winSize = Director::getInstance()->getWinSize();
+	const auto& winSize = Director::getInstance()->getWinSize();
 
 	auto descLabel = Label::createWithBMFont(GameToolbox::getTextureString("chatFont.fnt"), desc, TextHAlignment::CENTER);
 	width = descLabel->getContentSize().width + 32;

--- a/Source/AlertLayer.h
+++ b/Source/AlertLayer.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "PopupLayer.h"
-#include "MenuItemSpriteExtra.h"
+
+class MenuItemSpriteExtra;
 
 class AlertLayer : public PopupLayer {
 private:

--- a/Source/BaseGameLayer.cpp
+++ b/Source/BaseGameLayer.cpp
@@ -81,6 +81,7 @@ void BaseGameLayer::loadLevel()
 		for (GameObject* object : _allObjects)
 		{
 			int section = sectionForPos(object->getPositionX());
+			object->_section = section - 1 < 0 ? 0 : section - 1;
 			_sectionObjects[section - 1 < 0 ? 0 : section - 1].push_back(object);
 
 			object->setCascadeOpacityEnabled(false);

--- a/Source/BaseGameLayer.cpp
+++ b/Source/BaseGameLayer.cpp
@@ -81,7 +81,6 @@ void BaseGameLayer::loadLevel()
 		for (GameObject* object : _allObjects)
 		{
 			int section = sectionForPos(object->getPositionX());
-			object->_section = section - 1 < 0 ? 0 : section - 1;
 			_sectionObjects[section - 1 < 0 ? 0 : section - 1].push_back(object);
 
 			object->setCascadeOpacityEnabled(false);

--- a/Source/BaseGameLayer.cpp
+++ b/Source/BaseGameLayer.cpp
@@ -2,6 +2,8 @@
 #include "EffectGameObject.h"
 #include "GameToolbox.h"
 #include "external/json.hpp"
+#include "GJGameLevel.h"
+#include "external/benchmark.h"
 
 USING_NS_AX;
 
@@ -189,7 +191,7 @@ void BaseGameLayer::createObjectsFromSetup(std::string_view uncompressedLevelStr
 	firstPart.join();
 	secondPart.join();
 #else
-	for (auto objectDataSpecific : objData)
+	for (const auto& objectDataSpecific : objData)
 	{
 		GameObject* obj = GameObject::createFromString(objectDataSpecific);
 		if (obj)

--- a/Source/BaseGameLayer.h
+++ b/Source/BaseGameLayer.h
@@ -1,12 +1,23 @@
 #pragma once
-#include <axmol.h>
-#include "GJGameLevel.h"
-#include "GameObject.h"
-#include "GameToolbox.h"
-#include "external/benchmark.h"
+
+#include <vector>
+#include <string>
+#include <unordered_map>
+#include <span>
+
 #include "PlayerObject.h"
 #include "SpriteColor.h"
-#include <span>
+#include "2d/CCLayer.h"
+
+class GameObject;
+class BaseGameLayer;
+class GJGameLevel;
+
+namespace ax 
+{ 
+	class SpriteBatchNode; 
+	class ParticleBatchNode;
+}
 
 //follow structure
 //1. private members

--- a/Source/BaseGameLayer.h
+++ b/Source/BaseGameLayer.h
@@ -93,7 +93,7 @@ protected:
 public:
     static BaseGameLayer* create(GJGameLevel*);
     bool init(GJGameLevel*);
-	int sectionForPos(float x);
+	static int sectionForPos(float x);
 	static BaseGameLayer* getInstance() {return _instance;}
 	bool isObjectBlending(GameObject* obj);
 };

--- a/Source/BaseGameLayer.h
+++ b/Source/BaseGameLayer.h
@@ -93,7 +93,7 @@ protected:
 public:
     static BaseGameLayer* create(GJGameLevel*);
     bool init(GJGameLevel*);
-	static int sectionForPos(float x);
+	int sectionForPos(float x);
 	static BaseGameLayer* getInstance() {return _instance;}
 	bool isObjectBlending(GameObject* obj);
 };

--- a/Source/BoomScrollLayer.cpp
+++ b/Source/BoomScrollLayer.cpp
@@ -3,6 +3,9 @@
 #include "MenuItemSpriteExtra.h"
 #include "AudioEngine.h"
 #include "GameToolbox.h"
+#include "2d/CCActionEase.h"
+#include "CCDirector.h"
+#include "CCEventDispatcher.h"
 
 USING_NS_AX;
 
@@ -97,7 +100,7 @@ bool BoomScrollLayer::init(std::vector<ax::Layer*> layers, int currentPage)
 	_internalLayer = Layer::create();
 	_internalLayer->setAnchorPoint(Vec2::ANCHOR_MIDDLE);
 	auto dir = Director::getInstance();
-	auto winSize = dir->getWinSize();
+	const auto& winSize = dir->getWinSize();
 	if (_internalLayer->getChildrenCount() < _totalPages)
 	{
 		int i = 0;

--- a/Source/BoomScrollLayer.h
+++ b/Source/BoomScrollLayer.h
@@ -1,6 +1,10 @@
 #pragma once
 
-#include <axmol.h>
+#include <string>
+#include <vector>
+
+#include "2d/CCLayer.h"
+#include "2d/CCActionTween.h"
 
 class BoomScrollLayer : public ax::Layer, public ax::ActionTweenDelegate {
 private:

--- a/Source/ButtonSprite.cpp
+++ b/Source/ButtonSprite.cpp
@@ -1,6 +1,12 @@
 #include "ButtonSprite.h"
 #include "GameToolbox.h"
 #include "MenuItemSpriteExtra.h"
+#include "2d/CCLabel.h"
+#include "ui/UIScale9Sprite.h"
+#include "CCDirector.h"
+#include "renderer/CCTextureCache.h"
+
+USING_NS_AX;
 
 ButtonSprite* ButtonSprite::create(std::string_view caption, int width, int minWidth, float scale, bool absoluteWidth, std::string_view font, std::string_view texture, float height)
 {
@@ -57,10 +63,10 @@ bool ButtonSprite::initWithText(std::string_view caption, int width, int minWidt
 	if (font == GameToolbox::getTextureString("bigFont.fnt"))
 		_spriteOffset = { -1, 2 };
 
-	_label = Label::createWithBMFont(font, "");
+	_label = ax::Label::createWithBMFont(font, "");
 	this->addChild(_label, 1);
 
-	_buttonTexture = ui::Scale9Sprite::create(texture, Rect(0, 0, 40, 40));
+	_buttonTexture = ui::Scale9Sprite::create(texture, ax::Rect(0, 0, 40, 40));
 	_buttonTexture->setContentSize({ 16, 16 });
 	this->addChild(_buttonTexture, 0);
 
@@ -90,7 +96,7 @@ bool ButtonSprite::initWithSprite(Sprite* iconSprite, int width, int minWidth, f
 	}
 	else
 	{
-		_buttonTexture = ui::Scale9Sprite::create(texture, Rect(0, 0, 40, 40));
+		_buttonTexture = ui::Scale9Sprite::create(texture, ax::Rect(0, 0, 40, 40));
 		_buttonTexture->setContentSize({ 16,16 });
 		this->addChild(_buttonTexture, 0);
 	}
@@ -126,7 +132,7 @@ void ButtonSprite::updateBGImage(std::string_view file)
 	{
 		_buttonTexture->removeFromParent();
 		
-		_buttonTexture = ui::Scale9Sprite::create(file, Rect(0, 0, 40, 40));
+		_buttonTexture = ax::ui::Scale9Sprite::create(file, ax::Rect(0, 0, 40, 40));
 		_buttonTexture->setContentSize({ 16, 16 });
 
 		this->addChild(_buttonTexture, 0);

--- a/Source/ButtonSprite.h
+++ b/Source/ButtonSprite.h
@@ -1,20 +1,32 @@
 #pragma once
 
-#include <axmol.h>
-#include <ui/CocosGUI.h>
+#include <string_view>
 
-USING_NS_AX;
+#include "2d/CCSprite.h"
+#include "math/Vec2.h"
+#include "ccTypes.h"
 
-class ButtonSprite : public Sprite
+namespace ax 
+{ 
+	class Label;
+
+	namespace ui 
+	{ 
+		class Scale9Sprite; 
+	} 
+}
+
+
+class ButtonSprite : public ax::Sprite
 {
-	ui::Scale9Sprite* _buttonTexture;
+	ax::ui::Scale9Sprite* _buttonTexture;
 	Sprite* _subSprite;
 	Sprite* _subBGSprite;
 
 	float _minWidth;
-	Point _spriteOffset;
+	ax::Point _spriteOffset;
 
-	Label* _label;
+	ax::Label* _label;
 
 	float _scale;
 	float _width;
@@ -77,6 +89,6 @@ public:
 
 	void updateBGImage(std::string_view file);
 	void setString(std::string_view str);
-	void setColor(Color3B color);
+	void setColor(ax::Color3B color);
 	void updateSpriteBGSize();
 };

--- a/Source/Checkbox.h
+++ b/Source/Checkbox.h
@@ -1,8 +1,17 @@
 #pragma once
-#include <axmol.h>
+#include <functional>
+#include <string_view>
+
 #include "MenuItemSpriteExtra.h"
 
+namespace ax 
+{ 
+	class Node; 
+}
+
+
 using CheckboxCallback = const std::function<void(ax::Node*, bool)>&;
+
 class Checkbox : public MenuItemSpriteExtra {
 public:
 	Checkbox(std::string_view off, std::string_view on, bool toggled, CheckboxCallback callback);

--- a/Source/CircleWave.cpp
+++ b/Source/CircleWave.cpp
@@ -1,4 +1,9 @@
 #include "CircleWave.h"
+#include "glad/gl.h"
+#include "CCDirector.h"
+#include "2d/CCActionInstant.h"
+#include "2d/CCActionManager.h"
+#include "2d/CCActionEase.h"
 
 USING_NS_AX;
 

--- a/Source/CircleWave.h
+++ b/Source/CircleWave.h
@@ -1,5 +1,16 @@
 #pragma once
-#include <axmol.h>
+#include <string_view>
+
+#include "2d/CCDrawNode.h"
+#include "2d/CCActionTween.h"
+#include "CCPlatformMacros.h"
+
+namespace ax 
+{
+	class Renderer;
+	class Mat4;
+	class Node;
+}
 
 class CircleWave : public ax::DrawNode, public ax::ActionTweenDelegate {
 private:

--- a/Source/ColorAction.cpp
+++ b/Source/ColorAction.cpp
@@ -1,5 +1,6 @@
 #include "ColorAction.h"
 #include "2d/CCActionTween.h"
+#include "SpriteColor.h"
 
 ColorAction* ColorAction::create(float duration, SpriteColor* target, ax::Color3B from, ax::Color3B to, float afrom ,
 								 float ato)

--- a/Source/ColorAction.h
+++ b/Source/ColorAction.h
@@ -1,6 +1,9 @@
 #pragma once
-#include <axmol.h>
-#include "SpriteColor.h"
+
+#include "2d/CCActionInterval.h"
+#include "ccTypes.h"
+
+class SpriteColor;
 
 class ColorAction : public ax::ActionInterval
 {

--- a/Source/CreatorLayer.cpp
+++ b/Source/CreatorLayer.cpp
@@ -11,6 +11,12 @@
 #include "MenuLayer.h"
 #include "PlayLayer.h"
 #include <network/HttpClient.h>
+#include "2d/CCMenu.h"
+#include "2d/CCTransition.h"
+#include "CCEventListenerKeyboard.h"
+#include "CCDirector.h"
+#include "CCEventDispatcher.h"
+#include "GJSearchObject.h"
 
 USING_NS_AX;
 using namespace ax::network;
@@ -41,7 +47,7 @@ bool CreatorLayer::init()
 		return false;
 
 	auto director = Director::getInstance();
-	auto winSize = director->getWinSize();
+	const auto& winSize = director->getWinSize();
 
 	GameToolbox::createBG(this);
 	GameToolbox::createAllCorners(this);

--- a/Source/CreatorLayer.h
+++ b/Source/CreatorLayer.h
@@ -1,6 +1,15 @@
 #pragma once
-#include <axmol.h>
-#include <ui/CocosGUI.h>
+#include "2d/CCScene.h"
+#include "CCEventKeyboard.h"
+
+namespace ax 
+{ 
+    class Event;
+    namespace ui 
+    { 
+        class TextField; 
+    } 
+}
 
 class CreatorLayer : public ax::Scene {
 public:

--- a/Source/DropDownLayer.cpp
+++ b/Source/DropDownLayer.cpp
@@ -1,4 +1,13 @@
 #include "DropDownLayer.h"
+#include "CCDirector.h"
+#include "2d/CCMenu.h"
+#include "MenuItemSpriteExtra.h"
+#include "ListLayer.h"
+#include "CCEventListenerTouch.h"
+#include "CCEventDispatcher.h"
+#include "2d/CCActionInterval.h"
+#include "2d/CCActionEase.h"
+#include "2d/CCActionInstant.h"
 
 USING_NS_AX;
 
@@ -72,7 +81,7 @@ bool DropDownLayer::init(Node* scrollLayer, const char* label)
 
 void DropDownLayer::showLayer(bool attachToScene, bool bounce)
 {
-	auto winSize = Director::getInstance()->getWinSize();
+	const auto& winSize = Director::getInstance()->getWinSize();
 
 	this->runAction(FadeTo::create(0.5, 125));
 	if (!bounce) this->_dropLayer->runAction(EaseInOut::create(MoveTo::create(0.5f, {this->getPositionX(), 0}), 2));
@@ -86,7 +95,7 @@ void DropDownLayer::showLayer(bool attachToScene, bool bounce)
 }
 
 void DropDownLayer::hideLayer(){
-	auto winSize = Director::getInstance()->getWinSize();
+	const auto& winSize = Director::getInstance()->getWinSize();
 
 	this->runAction(FadeTo::create(0.5, 0));
 	this->_dropLayer->runAction(

--- a/Source/DropDownLayer.h
+++ b/Source/DropDownLayer.h
@@ -1,18 +1,22 @@
 #pragma once
-#include <axmol.h>
-#include "GameToolbox.h"
-#include "MenuItemSpriteExtra.h"
-#include "ListLayer.h"
+#include "2d/CCLayer.h"
+
+class MenuItemSpriteExtra;
+
+namespace ax 
+{ 
+	class Node; 
+}
 
 class DropDownLayer : public ax::LayerColor {
 protected:
-	virtual bool init(Node* scrollLayer, const char* label);
+	virtual bool init(ax::Node* scrollLayer, const char* label);
 	virtual void customSetup() {};
 	MenuItemSpriteExtra *_backBtn;
 public:
 	ax::Layer* _dropLayer;
 
-	static DropDownLayer* create(Node* scrollLayer, const char* label);
+	static DropDownLayer* create(ax::Node* scrollLayer, const char* label);
 	void showLayer(bool attachToScene, bool bounce);
 	void hideLayer();
 	virtual void hideBackButton();

--- a/Source/EffectGameObject.cpp
+++ b/Source/EffectGameObject.cpp
@@ -4,6 +4,7 @@
 #include "GameToolbox.h"
 #include "MoveAction.h"
 #include "PlayLayer.h"
+#include "2d/CCActionEase.h"
 
 USING_NS_AX;
 
@@ -69,7 +70,7 @@ Action* EffectGameObject::actionEasing(ActionInterval* ac)
 	return ac;
 }
 
-void EffectGameObject::triggerActivated(float idk)
+void EffectGameObject::triggerActivated(float)
 {
 	if (!_bgl)
 		return;

--- a/Source/EffectGameObject.cpp
+++ b/Source/EffectGameObject.cpp
@@ -253,6 +253,13 @@ void EffectGameObject::triggerActivated(float)
 	}
 }
 
+void EffectGameObject::update(float dt)
+{
+	GameObject::update();
+	if (_scheduledRemoval && getNumberOfRunningActions() <= 0)
+		removeFromGameLayer();
+}
+
 void EffectGameObject::updateTweenAction(float value, std::string_view key)
 {
 	if (!_bgl)

--- a/Source/EffectGameObject.cpp
+++ b/Source/EffectGameObject.cpp
@@ -253,13 +253,6 @@ void EffectGameObject::triggerActivated(float)
 	}
 }
 
-void EffectGameObject::update(float dt)
-{
-	GameObject::update();
-	if(_scheduledRemoval && getNumberOfRunningActions() <= 0)
-		removeFromGameLayer();
-}
-
 void EffectGameObject::updateTweenAction(float value, std::string_view key)
 {
 	if (!_bgl)

--- a/Source/EffectGameObject.h
+++ b/Source/EffectGameObject.h
@@ -40,6 +40,8 @@ public:
 
 	bool _lockToPlayerX, _lockToPlayerY;
 
+	bool _scheduledRemoval;
+
 private:
 	virtual void updateTweenAction(float value, std::string_view key) override;
 	ax::Action* actionEasing(ax::ActionInterval* ac);
@@ -47,4 +49,5 @@ private:
 public:
 	void triggerActivated(float);
 	static EffectGameObject *create(std::string_view frame);
+	void update(float dt) override;
 };

--- a/Source/EffectGameObject.h
+++ b/Source/EffectGameObject.h
@@ -40,8 +40,6 @@ public:
 
 	bool _lockToPlayerX, _lockToPlayerY;
 
-	bool _scheduledRemoval;
-
 private:
 	virtual void updateTweenAction(float value, std::string_view key) override;
 	ax::Action* actionEasing(ax::ActionInterval* ac);
@@ -49,5 +47,4 @@ private:
 public:
 	void triggerActivated(float);
 	static EffectGameObject *create(std::string_view frame);
-	void update(float dt) override;
 };

--- a/Source/EffectGameObject.h
+++ b/Source/EffectGameObject.h
@@ -1,8 +1,16 @@
 #pragma once
+#include <string_view>
+
 #include "GameObject.h"
-#include <axmol.h>
+#include "ccTypes.h"
+#include "math/Vec2.h"
 
 class BaseGameLayer;
+namespace ax 
+{ 
+	class Action;
+	class ActionInterval;
+}
 
 class EffectGameObject : public GameObject
 {
@@ -37,6 +45,6 @@ private:
 	ax::Action* actionEasing(ax::ActionInterval* ac);
 
 public:
-	void triggerActivated(float idk);
+	void triggerActivated(float);
 	static EffectGameObject *create(std::string_view frame);
 };

--- a/Source/EndLevelLayer.cpp
+++ b/Source/EndLevelLayer.cpp
@@ -3,6 +3,12 @@
 #include "AudioEngine.h"
 #include <fmt/chrono.h>
 #include <array>
+#include "PlayLayer.h"
+#include "DropDownLayer.h"
+#include "2d/CCLabel.h"
+#include "2d/CCMenu.h"
+#include "MenuItemSpriteExtra.h"
+#include "UILayer.h"
 
 //same as LoadingLayer
 constexpr static auto _endingStrings = std::to_array <const char*>({
@@ -60,7 +66,7 @@ bool EndLevelLayer::init(PlayLayer *pl)
 	_playlayer = pl;
 	if (!_createdWithoutPlaylayer)
 		pl->m_pHudLayer->addChild(_statsLayer);
-	auto wsize = ax::Director::getInstance()->getWinSize();
+	const auto& wsize = ax::Director::getInstance()->getWinSize();
 
 	// image
 

--- a/Source/EndLevelLayer.h
+++ b/Source/EndLevelLayer.h
@@ -1,7 +1,12 @@
 #pragma once
-#include <axmol.h>
-#include "DropDownLayer.h"
-#include "PlayLayer.h"
+
+#include <string_view>
+
+#include "2d/CCLayer.h"
+
+class DropDownLayer;
+class PlayLayer;
+
 
 class EndLevelLayer : public ax::Layer {
 private:

--- a/Source/EndPortalObject.h
+++ b/Source/EndPortalObject.h
@@ -1,6 +1,11 @@
 #pragma once
 #include "GameObject.h"
-#include <axmol.h>
+
+namespace ax 
+{ 
+	class Sprite; 
+}
+
 
 class EndPortalObject : public GameObject
 {

--- a/Source/GJGameLevel.h
+++ b/Source/GJGameLevel.h
@@ -1,10 +1,8 @@
 #pragma once
-
 #include <string>
-#include <vector>
-#include <axmol.h>
-#include "GameToolbox.h"
+#include <string_view>
 
+class GJGameLevel;
 
 enum DifficultyType {
 	kMainLevels = 0,
@@ -68,7 +66,7 @@ public:
 
 	// Expects RobTop like string. If it not, nullptr gets returned.
 	static GJGameLevel *createWithResponse(std::string_view backendResponse);
-	GJGameLevel(){}
+	GJGameLevel() = default;
 	GJGameLevel(std::string levelName, int levelID);
 	static GJGameLevel *createWithMinimumData(
 		std::string levelName, 

--- a/Source/GJSearchObject.h
+++ b/Source/GJSearchObject.h
@@ -1,6 +1,8 @@
 #pragma once
+#include <string>
+#include <string_view>
 
-#include <axmol.h>
+#include "2d/CCNode.h"
 
 enum SearchType {
 	kGJSearchTypeLiked = 2,

--- a/Source/GameManager.h
+++ b/Source/GameManager.h
@@ -1,7 +1,7 @@
-#include <iostream>
-#include <fstream>
-#include <map>
-#include "GameToolbox.h"
+#pragma once
+#include <string>
+
+enum IconType;
 
 class GameManager
 {

--- a/Source/GameObject.cpp
+++ b/Source/GameObject.cpp
@@ -7,6 +7,7 @@
 #include "external/json.hpp"
 #include <fmt/format.h>
 #include <fstream>
+#include "2d/CCParticleSystemQuad.h"
 
 USING_NS_AX;
 

--- a/Source/GameObject.h
+++ b/Source/GameObject.h
@@ -142,9 +142,11 @@ class GameObject : public ax::Sprite, public ax::ActionTweenDelegate
 	int _zLayer = 0;
 
 	int _uniqueID = -1;
-	int _section = -1;
 
 	float _radius = -1;
+
+	//for move trigger
+	ax::Vec2 _prevPos;
 
 	ax::ParticleSystemQuad* _particle;
 

--- a/Source/GameObject.h
+++ b/Source/GameObject.h
@@ -1,9 +1,20 @@
 #pragma once
-#include <axmol.h>
+
+#include <string_view>
+#include <vector>
+#include <unordered_map>
 #include <map>
-#include <string>
+
+#include "2d/CCSprite.h"
+#include "2d/CCActionTween.h"
+#include "math/Rect.h"
+#include "math/Vec2.h"
 
 class PlayerObject;
+namespace ax 
+{ 
+	class ParticleSystemQuad; 
+}
 
 enum GameObjectType
 {

--- a/Source/GameObject.h
+++ b/Source/GameObject.h
@@ -142,11 +142,9 @@ class GameObject : public ax::Sprite, public ax::ActionTweenDelegate
 	int _zLayer = 0;
 
 	int _uniqueID = -1;
+	int _section = -1;
 
 	float _radius = -1;
-
-	//for move trigger
-	ax::Vec2 _prevPos;
 
 	ax::ParticleSystemQuad* _particle;
 

--- a/Source/GameToolbox.cpp
+++ b/Source/GameToolbox.cpp
@@ -4,6 +4,8 @@
 #include "AltDirector.h"
 #include "GameManager.h"
 #include "external/fast_float.h"
+#include "network/HttpResponse.h"
+#include "network/HttpClient.h"
 
 USING_NS_AX;
 

--- a/Source/GameToolbox.h
+++ b/Source/GameToolbox.h
@@ -1,17 +1,29 @@
 #pragma once
-#include <axmol.h>
 #include <string>
-#include <fmt/chrono.h>
+#include <string_view>
 #include <optional>
-#include <network/HttpClient.h>
-
-#include <regex>
-#include <sstream>
-#include <iostream>
-#include <filesystem>
-#include <string>
-
 #include <vector>
+#include <type_traits>
+
+#include "ccTypes.h"
+#include "CCVector.h"
+#include "math/Vec2.h"
+#include "CCFileUtils.h"
+#include "network/HttpRequest.h"
+#include "fmt/core.h"
+#include "fmt/chrono.h"
+
+namespace ax 
+{ 
+	class Label; 
+	class Menu;
+	class Node;
+	namespace network
+	{
+		ccHttpRequestCallback;
+	}
+}
+
 
 enum IconType {
 	kIconTypeCube		= 0,

--- a/Source/GarageLayer.cpp
+++ b/Source/GarageLayer.cpp
@@ -4,6 +4,13 @@
 #include "MenuLayer.h"
 #include "SimplePlayer.h"
 #include "GameManager.h"
+#include "ui/UITextField.h"
+#include "2d/CCTransition.h"
+#include "2d/CCMenu.h"
+#include "CCEventDispatcher.h"
+#include "ccUTF8.h"
+#include "CCEventListenerKeyboard.h"
+#include "ui/UIScale9Sprite.h"
 
 USING_NS_AX;
 
@@ -137,7 +144,7 @@ int GarageLayer::selectedGameModeInt()
 
 void GarageLayer::createStat(const char* sprite, const char* statKey)
 {
-	auto size = Director::getInstance()->getWinSize();
+	const auto& size = Director::getInstance()->getWinSize();
 
 	auto stat = Sprite::createWithSpriteFrameName(sprite);
 	stat->setScale(.65);
@@ -155,7 +162,7 @@ void GarageLayer::createStat(const char* sprite, const char* statKey)
 
 void GarageLayer::setupIconSelect()
 {
-	auto size = Director::getInstance()->getWinSize();
+	const auto& size = Director::getInstance()->getWinSize();
 
 	auto bg = ui::Scale9Sprite::create(GameToolbox::getTextureString("square02_001.png"));
 	bg->setContentSize({385, 100});

--- a/Source/GarageLayer.h
+++ b/Source/GarageLayer.h
@@ -1,8 +1,22 @@
 #pragma once
-#include <axmol.h>
-#include "SimplePlayer.h"
-#include <ui/CocosGUI.h>
 #include <array>
+
+#include "2d/CCScene.h"
+
+enum IconType;
+class SimplePlayer;
+
+namespace ax 
+{ 
+	class Menu;
+	class Sprite;
+
+	namespace ui 
+	{ 
+		class TextField; 
+	}
+}
+
 
 class GarageLayer : public ax::Scene {
 public:

--- a/Source/GroundLayer.h
+++ b/Source/GroundLayer.h
@@ -1,5 +1,16 @@
 #pragma once
-#include <axmol.h>
+
+#include <string_view>
+
+#include "2d/CCLayer.h"
+#include "2d/CCActionTween.h"
+#include "2d/CCAction.h"
+
+namespace ax 
+{ 
+	class Sprite; 
+}
+
 
 class GroundLayer : public ax::Layer, public ax::ActionTweenDelegate 
 {

--- a/Source/InfoLayer.cpp
+++ b/Source/InfoLayer.cpp
@@ -6,6 +6,11 @@
 #include <ui/UITextField.h>
 #include "external/base64.h"
 #include "ButtonSprite.h"
+#include "CCDirector.h"
+#include "GameToolbox.h"
+#include "2d/CCMenu.h"
+#include "GJGameLevel.h"
+#include "ccUTF8.h"
 
 USING_NS_AX;
 
@@ -26,7 +31,7 @@ InfoLayer* InfoLayer::create(GJGameLevel* level)
 bool InfoLayer::init(GJGameLevel* level)
 {
 	if (!PopupLayer::init()) return false;
-	auto winSize = Director::getInstance()->getWinSize();
+	const auto& winSize = Director::getInstance()->getWinSize();
 
 	auto bg = ui::Scale9Sprite::create(GameToolbox::getTextureString("GJ_square01.png"));
 	bg->setContentSize({ 420.0, 260.0 });

--- a/Source/InfoLayer.h
+++ b/Source/InfoLayer.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <axmol.h>
-#include "GJGameLevel.h"
 #include "PopupLayer.h"
+
+class GJGameLevel;
 
 class InfoLayer : public PopupLayer
 {

--- a/Source/LevelBrowserLayer.cpp
+++ b/Source/LevelBrowserLayer.cpp
@@ -1,6 +1,19 @@
 #include "LevelBrowserLayer.h"
 #include "LevelCell.h"
 #include "LevelSearchLayer.h"
+#include "2d/CCScene.h"
+#include "CCDirector.h"
+#include "LoadingCircle.h"
+#include "2d/CCMenu.h"
+#include "GameToolbox.h"
+#include "GJGameLevel.h"
+#include "GJSearchObject.h"
+#include "MenuItemSpriteExtra.h"
+#include "ui/UIListView.h"
+#include "CCEventDispatcher.h"
+#include "2d/CCLabel.h"
+#include "ListLayer.h"
+#include "CCEventListenerKeyboard.h"
 
 ax::Scene* LevelBrowserLayer::scene(GJSearchObject* search)
 {
@@ -32,7 +45,7 @@ bool LevelBrowserLayer::init(GJSearchObject* search)
 	_searchObj = search;
 
 	auto director = ax::Director::getInstance();
-	auto winSize = director->getWinSize();
+	const auto& winSize = director->getWinSize();
 
 	_loading = LoadingCircle::create();
 	_loading->setPosition(winSize.x/2, winSize.y/2);

--- a/Source/LevelBrowserLayer.h
+++ b/Source/LevelBrowserLayer.h
@@ -1,12 +1,30 @@
 #pragma once
+#include <unordered_map>
+#include <vector>
 
-#include <axmol.h>
-#include "GJSearchObject.h"
-#include "network/HttpClient.h"
-#include "ListLayer.h"
-#include "ui/UIListView.h"
-#include "GJGameLevel.h"
-#include "LoadingCircle.h"
+#include "2d/CCLayer.h"
+
+class GJSearchObject;
+class LoadingCircle;
+class MenuItemSpriteExtra;
+class GJGameLevel;
+
+namespace ax 
+{ 
+    class Scene; 
+    namespace ui
+    {
+        class ListView;
+    }
+
+    namespace network
+    {
+        class HttpClient;
+        class HttpResponse;
+    }
+}
+
+
 
 class LevelBrowserLayer : public ax::Layer {
 public:

--- a/Source/LevelCell.cpp
+++ b/Source/LevelCell.cpp
@@ -4,6 +4,12 @@
 #include "ui/UIScale9Sprite.h"
 #include "LevelInfoLayer.h"
 #include "ButtonSprite.h"
+#include "GJGameLevel.h"
+#include "2d/CCLabel.h"
+#include "2d/CCMenu.h"
+#include "fmt/core.h"
+#include "LevelTools.h"
+#include "2d/CCTransition.h"
 
 USING_NS_AX;
 

--- a/Source/LevelCell.h
+++ b/Source/LevelCell.h
@@ -1,8 +1,14 @@
 #pragma once
-#include <axmol.h>
-#include "GJGameLevel.h"
 #include "ui/UIWidget.h"
-#include "LevelTools.h"
+
+class GJGameLevel;
+
+namespace ax 
+{ 
+	class Layer;
+	class LayerColor; 
+}
+
 
 class LevelCell : public ax::ui::Widget {
 public:

--- a/Source/LevelDebugLayer.cpp
+++ b/Source/LevelDebugLayer.cpp
@@ -83,7 +83,8 @@ void LevelDebugLayer::onEnter()
 
 	dir->getEventDispatcher()->addEventListenerWithSceneGraphPriority(listener, this);
 
-	ImGuiPresenter::getInstance()->addRenderLoop("#playlayer", AX_CALLBACK_0(LevelDebugLayer::onDrawImgui, this), dir->getRunningScene());
+	ImGuiPresenter::getInstance()->addRenderLoop("#playlayer", AX_CALLBACK_0(LevelDebugLayer::onDrawImgui, this),
+												 dir->getRunningScene());
 }
 
 void LevelDebugLayer::onExit()
@@ -157,7 +158,7 @@ void LevelDebugLayer::onDrawImgui()
 
 	ImGui::InputInt("Color Channel", &channelID);
 
-	if(_colorChannels.contains(channelID))
+	if (_colorChannels.contains(channelID))
 	{
 		auto channel = _colorChannels[channelID];
 		int color[3] = {channel._color.r, channel._color.g, channel._color.b};
@@ -171,7 +172,7 @@ void LevelDebugLayer::onDrawImgui()
 
 	ImGui::InputInt("Group", &groupID);
 
-	if(_colorChannels.contains(groupID))
+	if (_colorChannels.contains(groupID))
 	{
 		auto group = _groups[groupID];
 		ImGui::InputFloat("Alpha", &group._alpha);
@@ -212,9 +213,10 @@ void LevelDebugLayer::onKeyPressed(EventKeyboard::KeyCode keyCode, Event* event)
 	}
 	case EventKeyboard::KeyCode::KEY_F: {
 		_showDebugMenu = !_showDebugMenu;
-		if(_showDebugMenu)
+		if (_showDebugMenu)
 			CocosExplorer::close();
-		else CocosExplorer::open();
+		else 
+			CocosExplorer::open();
 	}
 	break;
 	}
@@ -284,7 +286,8 @@ void LevelDebugLayer::updateTriggers(float dt)
 					if (obj->_isTrigger)
 					{
 						auto trigger = dynamic_cast<EffectGameObject*>(obj);
-						if (!trigger->_wasTriggerActivated && trigger->getPositionX() <= Camera::getDefaultCamera()->getPositionX())
+						if (!trigger->_wasTriggerActivated &&
+							trigger->getPositionX() <= Camera::getDefaultCamera()->getPositionX())
 						{
 							trigger->triggerActivated(dt);
 						}
@@ -395,6 +398,9 @@ void LevelDebugLayer::updateVisibility()
 						AX_SAFE_RELEASE(obj);
 					}
 
+					if (section[j]->_isTrigger)
+						static_cast<EffectGameObject*>(section[j])->_scheduledRemoval = false;
+
 					obj->setActive(true);
 					obj->update();
 				}
@@ -409,7 +415,10 @@ void LevelDebugLayer::updateVisibility()
 		{
 			if (section[j]->getParent() != nullptr)
 			{
-				section[j]->removeFromGameLayer();
+				if (section[j]->_isTrigger)
+					static_cast<EffectGameObject*>(section[j])->_scheduledRemoval = true;
+				else
+					section[j]->removeFromGameLayer();
 			}
 		}
 	}
@@ -421,7 +430,10 @@ void LevelDebugLayer::updateVisibility()
 		{
 			if (section[j]->getParent() != nullptr)
 			{
-				section[j]->removeFromGameLayer();
+				if (section[j]->_isTrigger)
+					static_cast<EffectGameObject*>(section[j])->_scheduledRemoval = true;
+				else
+					section[j]->removeFromGameLayer();
 			}
 		}
 	}

--- a/Source/LevelDebugLayer.cpp
+++ b/Source/LevelDebugLayer.cpp
@@ -10,6 +10,8 @@
 #include "ImGui/imgui/imgui.h"
 #include "ImGui/ImGuiPresenter.h"
 #include "CocosExplorer.h"
+#include "GJGameLevel.h"
+#include "2d/CCTransition.h"
 
 USING_NS_AX;
 USING_NS_AX_EXT;

--- a/Source/LevelDebugLayer.cpp
+++ b/Source/LevelDebugLayer.cpp
@@ -1,15 +1,17 @@
 #include "LevelDebugLayer.h"
-#include "CocosExplorer.h"
-#include "EffectGameObject.h"
 #include "GameToolbox.h"
-#include "ImGui/ImGuiPresenter.h"
-#include "ImGui/imgui/imgui.h"
 #include "LevelSearchLayer.h"
 #include "LevelSelectLayer.h"
 #include "MenuItemSpriteExtra.h"
 #include "format.h"
 #include <AudioEngine.h>
 #include <ccMacros.h>
+#include "EffectGameObject.h"
+#include "ImGui/imgui/imgui.h"
+#include "ImGui/ImGuiPresenter.h"
+#include "CocosExplorer.h"
+#include "GJGameLevel.h"
+#include "2d/CCTransition.h"
 
 USING_NS_AX;
 USING_NS_AX_EXT;
@@ -81,8 +83,7 @@ void LevelDebugLayer::onEnter()
 
 	dir->getEventDispatcher()->addEventListenerWithSceneGraphPriority(listener, this);
 
-	ImGuiPresenter::getInstance()->addRenderLoop("#playlayer", AX_CALLBACK_0(LevelDebugLayer::onDrawImgui, this),
-												 dir->getRunningScene());
+	ImGuiPresenter::getInstance()->addRenderLoop("#playlayer", AX_CALLBACK_0(LevelDebugLayer::onDrawImgui, this), dir->getRunningScene());
 }
 
 void LevelDebugLayer::onExit()
@@ -156,7 +157,7 @@ void LevelDebugLayer::onDrawImgui()
 
 	ImGui::InputInt("Color Channel", &channelID);
 
-	if (_colorChannels.contains(channelID))
+	if(_colorChannels.contains(channelID))
 	{
 		auto channel = _colorChannels[channelID];
 		int color[3] = {channel._color.r, channel._color.g, channel._color.b};
@@ -170,7 +171,7 @@ void LevelDebugLayer::onDrawImgui()
 
 	ImGui::InputInt("Group", &groupID);
 
-	if (_colorChannels.contains(groupID))
+	if(_colorChannels.contains(groupID))
 	{
 		auto group = _groups[groupID];
 		ImGui::InputFloat("Alpha", &group._alpha);
@@ -211,10 +212,9 @@ void LevelDebugLayer::onKeyPressed(EventKeyboard::KeyCode keyCode, Event* event)
 	}
 	case EventKeyboard::KeyCode::KEY_F: {
 		_showDebugMenu = !_showDebugMenu;
-		if (_showDebugMenu)
+		if(_showDebugMenu)
 			CocosExplorer::close();
-		else
-			CocosExplorer::open();
+		else CocosExplorer::open();
 	}
 	break;
 	}
@@ -284,8 +284,7 @@ void LevelDebugLayer::updateTriggers(float dt)
 					if (obj->_isTrigger)
 					{
 						auto trigger = dynamic_cast<EffectGameObject*>(obj);
-						if (!trigger->_wasTriggerActivated &&
-							trigger->getPositionX() <= Camera::getDefaultCamera()->getPositionX())
+						if (!trigger->_wasTriggerActivated && trigger->getPositionX() <= Camera::getDefaultCamera()->getPositionX())
 						{
 							trigger->triggerActivated(dt);
 						}
@@ -396,9 +395,6 @@ void LevelDebugLayer::updateVisibility()
 						AX_SAFE_RELEASE(obj);
 					}
 
-					if (section[j]->_isTrigger)
-						static_cast<EffectGameObject*>(section[j])->_scheduledRemoval = false;
-
 					obj->setActive(true);
 					obj->update();
 				}
@@ -413,10 +409,7 @@ void LevelDebugLayer::updateVisibility()
 		{
 			if (section[j]->getParent() != nullptr)
 			{
-				if (section[j]->_isTrigger)
-					static_cast<EffectGameObject*>(section[j])->_scheduledRemoval = true;
-				else
-					section[j]->removeFromGameLayer();
+				section[j]->removeFromGameLayer();
 			}
 		}
 	}
@@ -428,10 +421,7 @@ void LevelDebugLayer::updateVisibility()
 		{
 			if (section[j]->getParent() != nullptr)
 			{
-				if (section[j]->_isTrigger)
-					static_cast<EffectGameObject*>(section[j])->_scheduledRemoval = true;
-				else
-					section[j]->removeFromGameLayer();
+				section[j]->removeFromGameLayer();
 			}
 		}
 	}

--- a/Source/LevelDebugLayer.h
+++ b/Source/LevelDebugLayer.h
@@ -1,7 +1,17 @@
 #pragma once
-#include <axmol.h>
-
 #include "BaseGameLayer.h"
+#include "math/Vec2.h"
+#include "CCEventKeyboard.h"
+
+class GJGameLevel;
+
+namespace ax 
+{ 
+    class Sprite; 
+    class Scene;
+    class Event;
+}
+
 
 
 //follow structure

--- a/Source/LevelEditorLayer.h
+++ b/Source/LevelEditorLayer.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <axmol.h>
-#include "GJGameLevel.h"
+#include "2d/CCLayer.h"
+
+class GJGameLevel;
+
 
 class LevelEditorLayer : public ax::Layer {
 private:

--- a/Source/LevelInfoLayer.cpp
+++ b/Source/LevelInfoLayer.cpp
@@ -7,6 +7,18 @@
 #include "RateLevelLayer.h"
 #include "AlertLayer.h"
 #include "GarageLayer.h"
+#include "CCDirector.h"
+#include "GameToolbox.h"
+#include "2d/CCMenu.h"
+#include "network/HttpResponse.h"
+#include "GJGameLevel.h"
+#include "LoadingCircle.h"
+#include "CCEventDispatcher.h"
+#include "MenuItemSpriteExtra.h"
+#include "2d/CCLabel.h"
+#include "2d/CCTransition.h"
+#include "CCEventListenerKeyboard.h"
+#include "network/HttpClient.h"
 
 USING_NS_AX;
 
@@ -34,7 +46,7 @@ Scene* LevelInfoLayer::scene(GJGameLevel* level)
 bool LevelInfoLayer::init(GJGameLevel* level)
 {
 	if (!Layer::init()) return false;
-	auto winSize = Director::getInstance()->getWinSize();
+	const auto& winSize = Director::getInstance()->getWinSize();
 
 	_level = level;
 

--- a/Source/LevelInfoLayer.h
+++ b/Source/LevelInfoLayer.h
@@ -1,10 +1,21 @@
 #pragma once
+#include "2d/CCLayer.h"
 
-#include <axmol.h>
-#include "GJGameLevel.h"
-#include "network/HttpClient.h"
-#include "LoadingCircle.h"
-#include "MenuItemSpriteExtra.h"
+class LoadingCircle;
+class MenuItemSpriteExtra;
+class GJGameLevel;
+
+namespace ax 
+{ 
+	class Scene;
+	namespace network 
+	{ 
+		class HttpRequest; 
+		class HttpClient;
+		class HttpResponse;
+	} 
+}
+
 
 class LevelInfoLayer : public ax::Layer
 {

--- a/Source/LevelPage.cpp
+++ b/Source/LevelPage.cpp
@@ -4,6 +4,12 @@
 #include "PlayLayer.h"
 #include "LevelDebugLayer.h"
 #include <AudioEngine.h>
+#include "GameToolbox.h"
+#include "2d/CCLabel.h"
+#include "2d/CCMenu.h"
+#include "2d/CCTransition.h"
+#include "MenuLayer.h"
+#include "GJGameLevel.h"
 
 bool LevelPage::replacingScene = false;
 
@@ -23,7 +29,7 @@ bool LevelPage::init(GJGameLevel* level)
 	std::string barTexture = GameToolbox::getTextureString("GJ_progressBar_001.png");
 	std::string bigFontTexture = GameToolbox::getTextureString("bigFont.fnt");
 
-	auto winSize = ax::Director::getInstance()->getWinSize();
+	const auto& winSize = ax::Director::getInstance()->getWinSize();
 
 	//TODO: fix bars lol
 	auto normalBar = ax::Sprite::create(barTexture);

--- a/Source/LevelPage.h
+++ b/Source/LevelPage.h
@@ -1,7 +1,12 @@
 #pragma once
 
-#include <axmol.h>
-#include "GJGameLevel.h"
+#include "2d/CCLayer.h"
+
+class GJGameLevel;
+namespace ax 
+{ 
+	class Node; 
+}
 
 class LevelPage : public ax::Layer
 {

--- a/Source/LevelSearchLayer.cpp
+++ b/Source/LevelSearchLayer.cpp
@@ -6,6 +6,13 @@
 #include "MenuItemSpriteExtra.h"
 #include <ui/CocosGUI.h>
 #include "LevelBrowserLayer.h"
+#include "2d/CCMenu.h"
+#include "GJSearchObject.h"
+#include "TextInputNode.h"
+#include "2d/CCTransition.h"
+#include "CCEventListenerKeyboard.h"
+#include "CCEventDispatcher.h"
+#include "ccUTF8.h"
 
 USING_NS_AX;
 
@@ -25,7 +32,7 @@ Sprite* searchButton(std::string texture, std::string text, float scale, std::st
 	auto sprite = Sprite::createWithSpriteFrameName(texture);
 	auto menu = Menu::create();
 
-	auto content_size = sprite->getContentSize();
+	const auto& content_size = sprite->getContentSize();
 	auto label = Label::createWithBMFont(GameToolbox::getTextureString("bigFont.fnt"), text);
 	label->setScale(scale);
 	menu->addChild(label);

--- a/Source/LevelSearchLayer.h
+++ b/Source/LevelSearchLayer.h
@@ -1,9 +1,19 @@
 #pragma once
 
-#include <axmol.h>
-#include "GJSearchObject.h"
-#include "TextInputNode.h"
-#include <ui/CocosGUI.h>
+#include <vector>
+
+#include "2d/CCLayer.h"
+
+class GJSearchObject;
+class TextInputNode;
+
+namespace ax 
+{ 
+	class Ref; 
+	class Node;
+	class Menu;
+	class Scene;
+}
 
 class LevelSearchLayer : public ax::Layer {
 private:

--- a/Source/LevelSelectLayer.cpp
+++ b/Source/LevelSelectLayer.cpp
@@ -8,6 +8,13 @@
 #include "LevelPage.h"
 #include "SongsLayer.h"
 #include "Checkbox.h"
+#include "GroundLayer.h"
+#include "BoomScrollLayer.h"
+#include "2d/CCMenu.h"
+#include "2d/CCLabel.h"
+#include "CCEventListenerKeyboard.h"
+#include "2d/CCTransition.h"
+#include "CCEventDispatcher.h"
 
 USING_NS_AX;
 
@@ -37,7 +44,7 @@ bool LevelSelectLayer::init(int page)
 	if(!Layer::init()) return false;
 
 	auto director = Director::getInstance();
-	auto winSize = director->getWinSize();
+	const auto& winSize = director->getWinSize();
 
 	_background = Sprite::create("GJ_gradientBG.png");
 	_background->setAnchorPoint({0.0f, 0.0f});

--- a/Source/LevelSelectLayer.h
+++ b/Source/LevelSelectLayer.h
@@ -1,9 +1,14 @@
 #pragma once
+#include "2d/CCLayer.h"
 
-#include <axmol.h>
-#include "GroundLayer.h"
-#include "GJGameLevel.h"
-#include "BoomScrollLayer.h"
+class GroundLayer;
+class BoomScrollLayer;
+
+namespace ax 
+{ 
+	class Sprite;
+	class Scene;
+}
 
 
 class LevelSelectLayer : public ax::Layer {

--- a/Source/LevelTools.h
+++ b/Source/LevelTools.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <string>
-#include "SongObject.h"
+#include <string_view>
 
 namespace LevelTools {
 	bool verifyLevelIntegrity(std::string_view levelData, int id);

--- a/Source/ListLayer.cpp
+++ b/Source/ListLayer.cpp
@@ -1,4 +1,8 @@
 #include "ListLayer.h"
+#include "GameToolbox.h"
+
+#include "CCDirector.h"
+#include "2d/CCLabel.h"
 
 ListLayer* ListLayer::create(ax::Node* scrollLayer, const char* label, ax::Color4B color, ax::Vec2 size){
 	auto pRet = new(std::nothrow) ListLayer();
@@ -23,7 +27,7 @@ ListLayer* ListLayer::create(ax::Node* scrollLayer, const char* label){
 bool ListLayer::init(ax::Node* scrollLayer, const char* label, ax::Color4B color, ax::Vec2 size){
 	if(!this->initWithColor(color)) return false;
 	
-	auto winSize = ax::Director::getInstance()->getWinSize();
+	const auto& winSize = ax::Director::getInstance()->getWinSize();
 
 	this->setContentSize(size);
 	

--- a/Source/ListLayer.h
+++ b/Source/ListLayer.h
@@ -1,7 +1,13 @@
 #pragma once
-#include <axmol.h>
-#include "GameToolbox.h"
-#include "MenuItemSpriteExtra.h"
+#include "2d/CCLayer.h"
+#include "ccTypes.h"
+#include "math/Vec2.h"
+
+namespace ax 
+{ 
+	class Node; 
+}
+
 
 class ListLayer : public ax::LayerColor {
 	private:		

--- a/Source/LoadingCircle.h
+++ b/Source/LoadingCircle.h
@@ -1,6 +1,12 @@
 #pragma once
+#include "2d/CCLayer.h"
+#include "CCPlatformMacros.h"
 
-#include <axmol.h>
+namespace ax 
+{ 
+	class Sprite; 
+}
+
 
 class LoadingCircle : public ax::Layer {
 public:

--- a/Source/LoadingLayer.cpp
+++ b/Source/LoadingLayer.cpp
@@ -6,6 +6,13 @@
 
 #include "external/constants.h"
 #include <array>
+#include "2d/CCSpriteFrameCache.h"
+#include "CCDirector.h"
+#include "renderer/CCTextureCache.h"
+#include "2d/CCLabel.h"
+#include "SimpleProgressBar.h"
+#include "2d/CCActionInterval.h"
+#include "2d/CCActionInstant.h"
 
 USING_NS_AX;
 

--- a/Source/LoadingLayer.h
+++ b/Source/LoadingLayer.h
@@ -1,6 +1,15 @@
 #pragma once
-#include <axmol.h>
-#include "SimpleProgressBar.h"
+#include "2d/CCLayer.h"
+
+class SimpleProgressBar;
+
+namespace ax 
+{ 
+	class Scene; 
+	class SpriteFrameCache;
+	class TextureCache;
+}
+
 
 class LoadingLayer : public ax::Layer {
 public:

--- a/Source/MenuGameLayer.cpp
+++ b/Source/MenuGameLayer.cpp
@@ -1,5 +1,8 @@
 #include "MenuGameLayer.h"
 #include "GameToolbox.h"
+#include "GroundLayer.h"
+#include "2d/CCMenu.h"
+#include "PlayerObject.h"
 
 USING_NS_AX;
 
@@ -15,7 +18,7 @@ bool MenuGameLayer::init(){
 	this->startPos = Vec2(0, 105);
 
 	auto dir = Director::getInstance();
-	auto winSize = dir->getWinSize();
+	const auto& winSize = dir->getWinSize();
 
 	groundLayer = GroundLayer::create(1);
 	
@@ -89,7 +92,7 @@ bool MenuGameLayer::init(){
 }
 void MenuGameLayer::processPlayerMovement(float delta) {
 	float step = std::min(2.0f, delta * 60.0f);
-	auto winSize = Director::getInstance()->getWinSize();
+	const auto& winSize = Director::getInstance()->getWinSize();
 	step /= 4.0f;
 
 	this->player->setPositionX(this->player->getPositionX() + (step * 18.f));

--- a/Source/MenuGameLayer.h
+++ b/Source/MenuGameLayer.h
@@ -1,10 +1,19 @@
 #pragma once
+#include "2d/CCLayer.h"
+#include "math/Vec2.h"
+#include "CCPlatformMacros.h"
 
-//#include "PlayerObject.h"
+class PlayerObject;
+class GroundLayer;
 
-#include <axmol.h>
-#include "GroundLayer.h"
-#include "PlayerObject.h"
+namespace ax 
+{ 
+	class Sprite; 
+	class Menu;
+	class Scene;
+}
+
+
 
 class MenuGameLayer : public ax::Layer {
 public:

--- a/Source/MenuItemSpriteExtra.cpp
+++ b/Source/MenuItemSpriteExtra.cpp
@@ -1,4 +1,6 @@
 #include "MenuItemSpriteExtra.h"
+#include "2d/CCSprite.h"
+#include "2d/CCActionEase.h"
 
 USING_NS_AX;
 

--- a/Source/MenuItemSpriteExtra.h
+++ b/Source/MenuItemSpriteExtra.h
@@ -1,9 +1,20 @@
 #pragma once
-#include <axmol.h>
+
+#include <string_view>
+#include <functional>
+
+#include "2d/CCMenuItem.h"
+#include "math/Vec2.h"
+
+namespace ax 
+{ 
+	class Node; 
+}
+
 
 class MenuItemSpriteExtra : public ax::MenuItemSprite {
 public:
-	MenuItemSpriteExtra(std::string_view sprite, ax::Node* sprNode, std::function<void(Node*)> callback);
+	MenuItemSpriteExtra(std::string_view sprite, ax::Node* sprNode, std::function<void(ax::Node*)> callback);
 	bool init() override;
 	void selected() override;
 	void unselected() override;
@@ -25,11 +36,11 @@ public:
 	/// @param callback Runs when you release the button with mouse hovered. Can be a lambda func. The Node* param is the button itself
 	/// @return The button
 	static MenuItemSpriteExtra* create(std::string_view sprite, std::function<void(Node*)> callback);
-	static MenuItemSpriteExtra* create(ax::Node* , std::function<void(Node*)> callback);
+	static MenuItemSpriteExtra* create(ax::Node* , std::function<void(ax::Node*)> callback);
 	virtual void setScaleMultiplier(float);
 	void setDestination(ax::Vec2 dest);
 	
 	ax::Node* getSprite();
 	void setScale(float) override;
-	void setCallback(std::function<void(Node*)> callback);
+	void setCallback(std::function<void(ax::Node*)> callback);
 };

--- a/Source/MenuLayer.cpp
+++ b/Source/MenuLayer.cpp
@@ -17,6 +17,12 @@
 #include "GameManager.h"
 #include "OptionsLayer.h"
 #include "EndLevelLayer.h"
+#include "2d/CCTransition.h"
+#include "2d/CCMenu.h"
+#include "ios/CCApplication-ios.h"
+#include "2d/CCLabel.h"
+#include "CCEventDispatcher.h"
+#include "CCEventListenerKeyboard.h"
 
 /*
 #include "ColoursPalette.h"
@@ -74,7 +80,7 @@ bool MenuLayer::init()
 	addChild(_mgl, -1);
 
 	float offsetScale = 1.13F;
-	auto winSize = Director::getInstance()->getWinSize();
+	const auto& winSize = Director::getInstance()->getWinSize();
 
 	auto log_oSpr = Sprite::createWithSpriteFrameName("GJ_logo_001.png");
 	log_oSpr->setStretchEnabled(false);

--- a/Source/MenuLayer.h
+++ b/Source/MenuLayer.h
@@ -1,9 +1,15 @@
 #pragma once
 
-#include <axmol.h>
-#include "MenuGameLayer.h"
+#include "2d/CCLayer.h"
 
 class MenuItemSpriteExtra;
+class MenuGameLayer;
+
+namespace ax 
+{ 
+	class Scene; 
+	class Label;
+}
 
 extern bool music;
 

--- a/Source/MoreGamesLayer.cpp
+++ b/Source/MoreGamesLayer.cpp
@@ -1,5 +1,8 @@
 #include "MoreGamesLayer.h"
 #include "DropDownLayer.h"
+#include "2d/CCMenu.h"
+#include "PromoItemSprite.h"
+#include "CCApplication.h"
 
 MoreGamesLayer* MoreGamesLayer::create(){
 	auto pRet = new(std::nothrow) MoreGamesLayer();

--- a/Source/MoreGamesLayer.h
+++ b/Source/MoreGamesLayer.h
@@ -1,6 +1,6 @@
 #pragma once
-#include <axmol.h>
-#include "PromoItemSprite.h"
+
+#include "2d/CCLayer.h"
 
 class MoreGamesLayer : public ax::Layer {
 private:

--- a/Source/MotionTrail.cpp
+++ b/Source/MotionTrail.cpp
@@ -1,4 +1,5 @@
 #include "MotionTrail.h"
+#include "math/CCVertex.h"
 
 USING_NS_AX;
 

--- a/Source/MotionTrail.h
+++ b/Source/MotionTrail.h
@@ -1,7 +1,13 @@
 #pragma once
-#include <axmol.h>
-#include <map>
-#include <string>
+
+#include "2d/CCMotionStreak.h"
+
+namespace ax 
+{ 
+	class Texture2D;
+	struct Color3B; 
+}
+
 
 class MotionTrail : public ax::MotionStreak
 {

--- a/Source/MoveAction.cpp
+++ b/Source/MoveAction.cpp
@@ -21,31 +21,62 @@ MoveAction* MoveAction::create(float duration, const ax::Vec2& deltaPosition, Gr
 bool MoveAction::initWithDuration(float duration, const ax::Vec2& deltaPosition, GroupProperties* group)
 {
 	_group = group;
+	_posDelta = deltaPosition;
 	return MoveBy::initWithDuration(duration, deltaPosition);
 }
 
 void MoveAction::startWithTarget(ax::Node* target)
 {
 	ActionInterval::startWithTarget(target);
+	_prevPositions.clear();
 	for (auto obj : _group->_objects)
-		obj->_prevPos = obj->_startPosition = obj->getPosition();
+	{
+		_prevPositions.push_back(obj->getPosition());
+		_startPositions.push_back(obj->getPosition());
+	}
 	GameToolbox::log("action start");
 }
+
+ax::Vec2 currentPos, diff, newPos;
 
 void MoveAction::update(float time)
 {
 #if AX_ENABLE_STACKABLE_ACTIONS
+	size_t i = 0;
 	for (auto obj : _group->_objects)
 	{
-		ax::Vec2 currentPos = obj->getPosition();
-		ax::Vec2 diff = currentPos - obj->_prevPos;
-		obj->_startPosition = obj->_startPosition + diff;
-		ax::Vec2 newPos = obj->_startPosition + (ax::Vec2(_positionDelta.x, _positionDelta.y) * time);
+		currentPos = obj->getPosition();
+		diff = currentPos - _prevPositions[i];
+		_startPositions[i] = _startPositions[i] + diff;
+		newPos = _startPositions[i] + (_posDelta * time);
 		obj->setPosition(newPos);
-		obj->_prevPos = newPos;
+		_prevPositions[i] = newPos;
+		auto section = BaseGameLayer::sectionForPos(newPos.x);
+		section = section - 1 < 0 ? 0 : section - 1;
+		if (obj->_section != section)
+		{
+			auto bgl = BaseGameLayer::getInstance();
+			auto vec = &bgl->_sectionObjects[obj->_section];
+			vec->erase(std::remove_if(vec->begin(), vec->end(), [&](GameObject* a) { return a == obj; }), vec->end());
+			while (section >= bgl->_sectionObjects.size())
+			{
+				std::vector<GameObject*> vec;
+				bgl->_sectionObjects.push_back(vec);
+			}
+			bgl->_sectionObjects[section].push_back(obj);
+			obj->_section = section;
+		}
+		i++;
 	}
 #else
 	for (auto obj : _group->_objects)
 		_obj->setPosition3D(_startPosition + _positionDelta * t);
 #endif // AX_ENABLE_STACKABLE_ACTIONS
+}
+
+void MoveAction::stop()
+{
+	MoveBy::stop();
+	_prevPositions.clear();
+	_startPositions.clear();
 }

--- a/Source/MoveAction.cpp
+++ b/Source/MoveAction.cpp
@@ -1,5 +1,7 @@
 #include "MoveAction.h"
 #include "2d/CCActionInterval.h"
+#include "BaseGameLayer.h"
+#include "GameToolbox.h"
 
 MoveAction* MoveAction::create(float duration, const ax::Vec2& deltaPosition, GroupProperties* group)
 {

--- a/Source/MoveAction.h
+++ b/Source/MoveAction.h
@@ -1,7 +1,13 @@
 #pragma once
 
-#include "BaseGameLayer.h"
-#include <axmol.h>
+#include "2d/CCActionInterval.h"
+
+struct GroupProperties;
+namespace ax 
+{ 
+	class Node; 
+	class Vec2;
+}
 
 class MoveAction : public ax::MoveBy
 {

--- a/Source/MoveAction.h
+++ b/Source/MoveAction.h
@@ -11,12 +11,15 @@ namespace ax
 
 class MoveAction : public ax::MoveBy
 {
-  private:
+private:
 	GroupProperties* _group;
+	std::vector<ax::Vec2> _prevPositions, _startPositions;
+	ax::Vec2 _posDelta;
 
-  public:
+public:
 	virtual void update(float time) override;
-  virtual void startWithTarget(ax::Node* target) override;
-  bool initWithDuration(float duration, const ax::Vec2& deltaPosition, GroupProperties* group);
+	virtual void stop() override;
+	virtual void startWithTarget(ax::Node* target) override;
+	bool initWithDuration(float duration, const ax::Vec2& deltaPosition, GroupProperties* group);
 	static MoveAction* create(float duration, const ax::Vec2& deltaPosition, GroupProperties* group);
 };

--- a/Source/MoveAction.h
+++ b/Source/MoveAction.h
@@ -13,12 +13,9 @@ class MoveAction : public ax::MoveBy
 {
   private:
 	GroupProperties* _group;
-  std::vector<ax::Vec2> _prevPositions, _startPositions;
-  ax::Vec2 _posDelta;
 
   public:
 	virtual void update(float time) override;
-  virtual void stop() override;
   virtual void startWithTarget(ax::Node* target) override;
   bool initWithDuration(float duration, const ax::Vec2& deltaPosition, GroupProperties* group);
 	static MoveAction* create(float duration, const ax::Vec2& deltaPosition, GroupProperties* group);

--- a/Source/NodeSerializer.h
+++ b/Source/NodeSerializer.h
@@ -1,8 +1,11 @@
 #pragma once
-#include <string>
+#include <string_view>
 #include <external/json.hpp>
-#include <2d/CCNode.h>
-#include <base/ccTypes.h>
+
+namespace ax 
+{ 
+	class Node; 
+}
 
 namespace NodeSerializer
 {

--- a/Source/OptionsLayer.cpp
+++ b/Source/OptionsLayer.cpp
@@ -1,6 +1,9 @@
 #include "OptionsLayer.h"
 #include "ButtonSprite.h"
 #include "GameManager.h"
+#include "MenuItemSpriteExtra.h"
+#include "2d/CCMenu.h"
+#include "DropDownLayer.h"
 
 USING_NS_AX;
 

--- a/Source/OptionsLayer.h
+++ b/Source/OptionsLayer.h
@@ -1,6 +1,7 @@
 #pragma once
-#include <axmol.h>
-#include "DropDownLayer.h"
+
+#include "2d/CCLayer.h"
+
 
 class OptionsLayer : public ax::Layer {
 private:

--- a/Source/PlayLayer.cpp
+++ b/Source/PlayLayer.cpp
@@ -22,6 +22,11 @@
 #include <fstream>
 
 #include "LevelDebugLayer.h"
+#include "UILayer.h"
+#include "GJGameLevel.h"
+#include "GroundLayer.h"
+#include "SimpleProgressBar.h"
+#include "CircleWave.h"
 
 
 USING_NS_AX;
@@ -40,7 +45,7 @@ ax::Node* cameraFollow;
 
 Scene* PlayLayer::scene(GJGameLevel* level)
 {
-	return LevelDebugLayer::scene(level);
+	//return LevelDebugLayer::scene(level);
 	auto scene = Scene::create();
 	scene->addChild(PlayLayer::create(level));
 	return scene;

--- a/Source/PlayLayer.cpp
+++ b/Source/PlayLayer.cpp
@@ -45,7 +45,7 @@ ax::Node* cameraFollow;
 
 Scene* PlayLayer::scene(GJGameLevel* level)
 {
-	//return LevelDebugLayer::scene(level);
+	return LevelDebugLayer::scene(level);
 	auto scene = Scene::create();
 	scene->addChild(PlayLayer::create(level));
 	return scene;

--- a/Source/PlayLayer.h
+++ b/Source/PlayLayer.h
@@ -1,20 +1,32 @@
 #pragma once
-
-#include <axmol.h>
-
-#include "GroundLayer.h"
-#include "MenuItemSpriteExtra.h"
-#include "MenuLayer.h"
-#include "PlayerObject.h"
-#include "SimpleProgressBar.h"
-
-#include "GJGameLevel.h"
-#include "SpriteColor.h"
-#include "UILayer.h"
-#include "BaseGameLayer.h"
-
-#include <vector>
 #include <span>
+#include <string_view>
+#include <vector>
+
+#include "2d/CCLayer.h"
+#include "CCEventKeyboard.h"
+#include "BaseGameLayer.h"
+#include "SpriteColor.h"
+#include "CCPlatformMacros.h"
+#include "ccTypes.h"
+
+enum PlayerGamemode;
+
+class GJGameLevel;
+class GameObject;
+class SimpleProgressBar;
+class UILayer;
+class PlayerObject;
+class GroundLayer;
+class MenuItemSpriteExtra;
+
+namespace ax 
+{ 
+	class Event; 
+	class Sprite;
+	class Label;
+}
+
 
 class PlayLayer : public ax::Layer
 {

--- a/Source/PlayerObject.cpp
+++ b/Source/PlayerObject.cpp
@@ -2,6 +2,11 @@
 #include "AudioEngine.h"
 #include "GameToolbox.h"
 #include "PlayLayer.h"
+#include "2d/CCParticleSystem.h"
+#include "2d/CCParticleSystemQuad.h"
+#include "2d/CCActionInstant.h"
+#include "2d/CCActionEase.h"
+#include "CircleWave.h"
 
 USING_NS_AX;
 

--- a/Source/PlayerObject.h
+++ b/Source/PlayerObject.h
@@ -1,8 +1,19 @@
 #pragma once
-#include "CircleWave.h"
 #include "GameObject.h"
-#include <MotionTrail.h>
-#include <axmol.h>
+#include "ccTypes.h"
+#include "math/Vec2.h"
+
+class GameObject;
+class MotionTrail;
+
+namespace ax 
+{ 
+	class Layer; 
+	class Sprite;
+	class ParticleSystemQuad;
+	class Texture2D;
+}
+
 
 enum PlayerGamemode
 {

--- a/Source/PopupLayer.h
+++ b/Source/PopupLayer.h
@@ -1,5 +1,6 @@
 #pragma once
-#include <axmol.h>
+
+#include "2d/CCLayer.h"
 
 class PopupLayer : public ax::LayerColor {
 public:

--- a/Source/PromoItemSprite.cpp
+++ b/Source/PromoItemSprite.cpp
@@ -1,5 +1,6 @@
 #include "PromoItemSprite.h"
 #include "GameManager.h"
+#include "2d/CCSprite.h"
 USING_NS_AX;
 
 

--- a/Source/PromoItemSprite.h
+++ b/Source/PromoItemSprite.h
@@ -1,9 +1,17 @@
 #pragma once
-#include <axmol.h>
+#include <functional>
+
+#include "2d/CCMenuItem.h"
+
+namespace ax 
+{ 
+	class Node; 
+}
+
 
 class PromoItemSprite : public ax::MenuItemSprite {
 private:
-	PromoItemSprite(const char* sprite, std::function<void(Node*)> callback);
+	PromoItemSprite(const char* sprite, std::function<void(ax::Node*)> callback);
 	bool init() override;
 	void selected() override;
 	void unselected() override;
@@ -17,7 +25,7 @@ public:
 	/// @param sprite The name of the sprite
 	/// @param callback Runs when you release the button with mouse hovered. Can be a lambda func. The Node* param is the button itself
 	/// @return The button
-	static PromoItemSprite* create(const char* sprite, std::function<void(Node*)> callback);
+	static PromoItemSprite* create(const char* sprite, std::function<void(ax::Node*)> callback);
 	
 	ax::Node* getSprite();
 };

--- a/Source/RateLevelLayer.cpp
+++ b/Source/RateLevelLayer.cpp
@@ -4,6 +4,8 @@
 #include "GameToolbox.h"
 #include <ui/CocosGUI.h>
 #include "ButtonSprite.h"
+#include "2d/CCMenu.h"
+#include "ccUTF8.h"
 
 USING_NS_AX;
 
@@ -51,7 +53,7 @@ bool RateLevelLayer::init(int)
 	m_dSelectedDiff = 0;
 
 	if (!PopupLayer::init()) return false;
-	auto winSize = Director::getInstance()->getWinSize();
+	const auto& winSize = Director::getInstance()->getWinSize();
 
 	auto bg = ui::Scale9Sprite::create(GameToolbox::getTextureString("GJ_square01.png"));
 	bg->setContentSize({ 360, 180 });

--- a/Source/RateLevelLayer.h
+++ b/Source/RateLevelLayer.h
@@ -1,8 +1,15 @@
 #pragma once
 
-#include <axmol.h>
 #include "PopupLayer.h"
-#include "MenuItemSpriteExtra.h"
+
+class MenuItemSpriteExtra;
+class RateLevelLayer;
+
+namespace ax 
+{ 
+	class Node; 
+}
+
 
 class RateLevelLayer : public PopupLayer
 {

--- a/Source/ResourcesLoadingLayer.h
+++ b/Source/ResourcesLoadingLayer.h
@@ -1,8 +1,18 @@
 #pragma once
 
-#include <axmol.h>
+#include <string>
+
+#include "2d/CCLayer.h"
+#include "math/Vec2.h"
 
 class GameManager;
+namespace ax 
+{ 
+	class RepeatForever; 
+	class Director;
+	class FileUtils;
+	class Scene;
+}
 
 class ResourcesLoadingLayer : public ax::Layer
 {

--- a/Source/SimplePlayer.cpp
+++ b/Source/SimplePlayer.cpp
@@ -1,5 +1,7 @@
 #include "SimplePlayer.h"
 #include "GameToolbox.h"
+#include "ccUTF8.h"
+
 USING_NS_AX;
 
 bool SimplePlayer::init(int cubeID) {

--- a/Source/SimplePlayer.h
+++ b/Source/SimplePlayer.h
@@ -1,6 +1,9 @@
 #pragma once
-#include <axmol.h>
-#include "GameToolbox.h"
+
+#include "2d/CCSprite.h"
+#include "ccTypes.h"
+
+enum IconType;
 
 class SimplePlayer : public ax::Sprite {
 public:

--- a/Source/SimpleProgressBar.h
+++ b/Source/SimpleProgressBar.h
@@ -1,6 +1,13 @@
 #pragma once
 
-#include <axmol.h>
+#include "2d/CCLayer.h"
+#include "CCPlatformMacros.h"
+
+namespace ax 
+{ 
+	class Sprite; 
+}
+
 
 // opengd addition
 class SimpleProgressBar : public ax::Layer {

--- a/Source/SongCell.cpp
+++ b/Source/SongCell.cpp
@@ -5,6 +5,9 @@
 #include "ui/UIScale9Sprite.h"
 #include "MenuItemSpriteExtra.h"
 #include "SongInfoLayer.h"
+#include "SongObject.h"
+#include "2d/CCLabel.h"
+#include "2d/CCMenu.h"
 
 USING_NS_AX;
 
@@ -40,7 +43,7 @@ bool SongCell::init(SongObject* songInfo)
 	_layer->setContentSize(this->getContentSize());
 	this->addChild(_layer);
 
-	auto contentSize = this->getContentSize();
+	const auto& contentSize = this->getContentSize();
 	auto sID = songInfo->_songID;
 
 

--- a/Source/SongCell.h
+++ b/Source/SongCell.h
@@ -1,8 +1,15 @@
 #pragma once
 
-#include <axmol.h>
-#include <ui/UIWidget.h>
-#include "SongObject.h"
+#include "ui/UIWidget.h"
+
+class SongObject;
+
+namespace ax 
+{
+	class Layer; 
+	class LayerColor;
+}
+
 
 class SongCell : public ax::ui::Widget
 {

--- a/Source/SongInfoLayer.cpp
+++ b/Source/SongInfoLayer.cpp
@@ -4,6 +4,9 @@
 #include "LevelTools.h"
 #include "MenuItemSpriteExtra.h"
 #include "ButtonSprite.h"
+#include "2d/CCLabel.h"
+#include "CCApplication.h"
+#include "2d/CCMenu.h"
 
 USING_NS_AX;
 
@@ -39,7 +42,7 @@ bool SongInfoLayer::init(std::string_view songName, std::string_view artistName,
 	if (!PopupLayer::init())
 		return false;
 	
-	auto winSize = Director::getInstance()->getWinSize();
+	const auto& winSize = Director::getInstance()->getWinSize();
 
 	_downloadLink = urlLink;
 	_ngArtistLink = ngArtistLink;

--- a/Source/SongInfoLayer.h
+++ b/Source/SongInfoLayer.h
@@ -1,7 +1,10 @@
 #pragma once
 
-#include <axmol.h>
+#include <string>
+#include <string_view>
+
 #include "PopupLayer.h"
+
 
 class SongInfoLayer : public PopupLayer
 {

--- a/Source/SongObject.h
+++ b/Source/SongObject.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <axmol.h>
+#include "2d/CCNode.h"
+
 
 class SongObject : ax::Node
 {

--- a/Source/SongsLayer.h
+++ b/Source/SongsLayer.h
@@ -1,8 +1,8 @@
 #pragma once
-
-#include <axmol.h>
 #include "DropDownLayer.h"
-#include <ui/CocosGUI.h>
+#include "ui/UIListView.h"
+
+
 
 class SongsLayer : public DropDownLayer
 {

--- a/Source/SpriteColor.h
+++ b/Source/SpriteColor.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <axmol.h>
+#include "ccTypes.h"
 
 class SpriteColor
 {
@@ -11,5 +11,5 @@ class SpriteColor
 	int _copyingColorID = -1;
 
 	SpriteColor(ax::Color3B color, float opacity, bool blending) : _color(color), _opacity(opacity), _blending(blending) {}
-	SpriteColor() {};
+	SpriteColor() = default;
 };

--- a/Source/TextButton.cpp
+++ b/Source/TextButton.cpp
@@ -1,6 +1,7 @@
 #include "TextButton.h"
 #include <ui/CocosGUI.h>
 #include "GameToolbox.h"
+#include "2d/CCActionEase.h"
 
 USING_NS_AX;
 

--- a/Source/TextButton.h
+++ b/Source/TextButton.h
@@ -1,6 +1,19 @@
 #pragma once
-#include <axmol.h>
-#include <string>
+
+#include <string_view>
+#include <functional>
+
+#include "2d/CCMenuItem.h"
+#include "CCPlatformMacros.h"
+
+namespace ax 
+{ 
+	class Label;
+	namespace ui 
+	{ 
+		class Scale9Sprite; 
+	} 
+}
 
 class TextButton : public ax::MenuItemSprite {
 private:

--- a/Source/TextInputNode.cpp
+++ b/Source/TextInputNode.cpp
@@ -2,6 +2,11 @@
 
 #include <ui/CocosGUI.h>
 #include <fmt/format.h>
+#include "CCEventListenerTouch.h"
+#include "CCEventListenerKeyboard.h"
+#include "CCDirector.h"
+#include "CCEventDispatcher.h"
+#include "axmol.h"
 
 USING_NS_AX;
 
@@ -106,7 +111,7 @@ bool TextInputNode::onTouchBegan(Touch* touch, Event* event)
 
 	auto nodeTouchPoint = this->convertTouchToNodeSpace(touch);
 
-	auto contentSize = this->getContentSize();
+	const auto& contentSize = this->getContentSize();
 	auto boundingBox = Rect(0, 0, contentSize.width, contentSize.height);
 
 	bool touchInside = boundingBox.containsPoint(nodeTouchPoint);

--- a/Source/TextInputNode.h
+++ b/Source/TextInputNode.h
@@ -1,9 +1,24 @@
 #pragma once
 
-#include <axmol.h>
-#include <ui/CocosGUI.h>
+#include <string>
+#include <string_view>
+
+#include "2d/CCLayer.h"
+#include "ccTypes.h"
+
+enum class KeyCode;
 
 class TextInputDelegate;
+
+namespace ax
+{ 
+	class Label;
+	class Event; 
+	namespace ui
+	{
+		class TextField;
+	}
+}
 
 class TextInputNode : public ax::Layer
 {

--- a/Source/UILayer.cpp
+++ b/Source/UILayer.cpp
@@ -1,6 +1,8 @@
 #include "UILayer.h"
 #include "PlayLayer.h"
 #include "GameToolbox.h"
+#include "CCEventListenerTouch.h"
+#include "CCEventDispatcher.h"
 
 UILayer* UILayer::create()
 {

--- a/Source/UILayer.h
+++ b/Source/UILayer.h
@@ -1,5 +1,12 @@
 #pragma once
-#include <axmol.h>
+
+#include "2d/CCLayer.h"
+
+namespace ax 
+{ 
+	class Touch; 
+	class Event;
+}
 
 class UILayer : public ax::Layer {
 public:


### PR DESCRIPTION
All header files in the main OpenGD project now only include the files they actually need and forward declare the rest. This also then includes the needed files in the .cpp files wherever needed. This should help improve compile times as well as reduce how often specific files need to be recompiled when changes get made as the dependencies are as minimal as possible.
