### PR TITLE
Fix build issues and package name for Android

### DIFF
--- a/Source/CircleWave.cpp
+++ b/Source/CircleWave.cpp
@@ -1,5 +1,5 @@
 #include "CircleWave.h"
-#include "glad/gl.h"
+#include "platform/CCGL.h"
 #include "CCDirector.h"
 #include "2d/CCActionInstant.h"
 #include "2d/CCActionManager.h"

--- a/Source/GameManager.cpp
+++ b/Source/GameManager.cpp
@@ -198,31 +198,31 @@ int GameManager::getSelectedIcon(IconType mode)
 {
 	switch (mode)
 	{
-	case kIconTypeCube: return _selectedCube;
-	case kIconTypeShip: return _selectedShip;
-	case kIconTypeBall: return _selectedBall;
-	case kIconTypeUfo: return _selectedUfo;
-	case kIconTypeWave: return _selectedWave;
-	case kIconTypeRobot: return _selectedRobot;
-	case kIconTypeSpider: return _selectedSpider;
-	case kIconTypeSpecial: return _selectedSpecial;
-	case kIconTypeDeathEffect: return _selectedDeathEffect;
-	default: return 0;
+		case IconType::kIconTypeCube: return _selectedCube;
+		case IconType::kIconTypeShip: return _selectedShip;
+		case IconType::kIconTypeBall: return _selectedBall;
+		case IconType::kIconTypeUfo: return _selectedUfo;
+		case IconType::kIconTypeWave: return _selectedWave;
+		case IconType::kIconTypeRobot: return _selectedRobot;
+		case IconType::kIconTypeSpider: return _selectedSpider;
+		case IconType::kIconTypeSpecial: return _selectedSpecial;
+		case IconType::kIconTypeDeathEffect: return _selectedDeathEffect;
+		default: return 0;
 	}
 }
 
 void GameManager::setSelectedIcon(IconType mode, int id) {
 	switch (mode)
 	{
-	case kIconTypeCube: _selectedCube = id; break;
-	case kIconTypeShip: _selectedShip = id; break;
-	case kIconTypeBall: _selectedBall = id; break;
-	case kIconTypeUfo: _selectedUfo = id; break;
-	case kIconTypeWave: _selectedWave = id; break;
-	case kIconTypeRobot: _selectedRobot = id; break;
-	case kIconTypeSpider: _selectedSpider = id; break;
-	case kIconTypeSpecial: _selectedSpecial = id; break;
-	case kIconTypeDeathEffect: _selectedDeathEffect = id; break;
+		case IconType::kIconTypeCube: _selectedCube = id; break;
+		case IconType::kIconTypeShip: _selectedShip = id; break;
+		case IconType::kIconTypeBall: _selectedBall = id; break;
+		case IconType::kIconTypeUfo: _selectedUfo = id; break;
+		case IconType::kIconTypeWave: _selectedWave = id; break;
+		case IconType::kIconTypeRobot: _selectedRobot = id; break;
+		case IconType::kIconTypeSpider: _selectedSpider = id; break;
+		case IconType::kIconTypeSpecial: _selectedSpecial = id; break;
+		case IconType::kIconTypeDeathEffect: _selectedDeathEffect = id; break;
 	}
 }
 

--- a/Source/GameManager.h
+++ b/Source/GameManager.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <string>
 
-enum IconType;
+enum class IconType : int;
 
 class GameManager
 {

--- a/Source/GameObject.cpp
+++ b/Source/GameObject.cpp
@@ -402,8 +402,8 @@ GameObject* GameObject::createFromString(std::string_view data)
 
 	std::string_view frame = GameObject::_pBlocks.at(objectID);
 
-	// actually create the object, use std::ranges
-	if (objectID != 1 && std::ranges::find(GameObject::_pTriggers, objectID) != GameObject::_pTriggers.end())
+	// actually create the object
+	if (objectID != 1 && std::find(GameObject::_pTriggers.begin(), GameObject::_pTriggers.end(), objectID) != GameObject::_pTriggers.end())
 	{
 		// mylock.lock();
 		obj = EffectGameObject::create(frame);

--- a/Source/GameToolbox.cpp
+++ b/Source/GameToolbox.cpp
@@ -12,6 +12,7 @@
 #include "2d/CCMenu.h"
 #include "math/MathUtil.h"
 #include "platform/CCFileUtils.h"
+#include <charconv>
 
 USING_NS_AX;
 
@@ -315,24 +316,24 @@ void GameToolbox::createBG(ax::Node* self) {
 
 int GameToolbox::getValueForGamemode(IconType mode) {
 		switch (mode) {
-		case kIconTypeCube:
+		case IconType::kIconTypeCube:
 			return 142;
-		case kIconTypeShip:
+		case IconType::kIconTypeShip:
 			return 51;
-		case kIconTypeBall:
+		case IconType::kIconTypeBall:
 			return 43;
-		case kIconTypeUfo:
-		case kIconTypeWave:
+		case IconType::kIconTypeUfo:
+		case IconType::kIconTypeWave:
 			return 35;
-		case kIconTypeRobot:
+		case IconType::kIconTypeRobot:
 			return 26;
-		case kIconTypeSpider:
+		case IconType::kIconTypeSpider:
 			return 17;
-		case kIconTypeSwing:
+		case IconType::kIconTypeSwing:
 			return 0;
-		case kIconTypeDeathEffect:
+		case IconType::kIconTypeDeathEffect:
 			return 17;
-		case kIconTypeSpecial:
+		case IconType::kIconTypeSpecial:
 			return 7;
 		default:
 			return 0;
@@ -340,19 +341,19 @@ int GameToolbox::getValueForGamemode(IconType mode) {
 }
 const char* GameToolbox::getNameGamemode(IconType mode) {
 		switch (mode) {
-		case kIconTypeShip:
+		case IconType::kIconTypeShip:
 			return "ship";
-		case kIconTypeBall:
+		case IconType::kIconTypeBall:
 			return "player_ball";
-		case kIconTypeUfo:
+		case IconType::kIconTypeUfo:
 			return "bird";
-		case kIconTypeWave:
+		case IconType::kIconTypeWave:
 			return "dart";
-		case kIconTypeRobot:
+		case IconType::kIconTypeRobot:
 			return "robot";
-		case kIconTypeSpider:
+		case IconType::kIconTypeSpider:
 			return "spider";
-		case kIconTypeSwing:
+		case IconType::kIconTypeSwing:
 			return "swing";
 		default:
 			return "player";

--- a/Source/GameToolbox.h
+++ b/Source/GameToolbox.h
@@ -23,7 +23,7 @@ namespace ax
 }
 
 
-enum IconType {
+enum class IconType {
 	kIconTypeCube		= 0,
 	kIconTypeShip		= 1,
 	kIconTypeBall		= 2,

--- a/Source/GarageLayer.cpp
+++ b/Source/GarageLayer.cpp
@@ -91,7 +91,7 @@ bool GarageLayer::init()
 	menu->addChild(backBtn);
 
 	auto shop = MenuItemSpriteExtra::create("shopRope_001.png", [=](Node*) {
-		_iconPrev->updateGamemode(35, kIconTypeUfo);
+		_iconPrev->updateGamemode(35, IconType::kIconTypeUfo);
 	});
 
 	shop->setPosition({135, size.height - 25});
@@ -135,9 +135,9 @@ bool GarageLayer::init()
 
 int GarageLayer::selectedGameModeInt()
 {
-	if (_selectedMode == kIconTypeSpecial)
+	if (_selectedMode == IconType::kIconTypeSpecial)
 		return 7;
-	if (_selectedMode == kIconTypeDeathEffect)
+	if (_selectedMode == IconType::kIconTypeDeathEffect)
 		return 8;
 
 	return static_cast<int>(_selectedMode);
@@ -188,12 +188,16 @@ void GarageLayer::setupIconSelect()
 		{
 			int tag = a->getTag();
 			int page = _modePages[tag];
-			if (tag == 7)
-				tag = kIconTypeSpecial;
-			if (tag == 8)
-				tag = kIconTypeDeathEffect;
 
-			this->setupPage(static_cast<IconType>(tag), page);
+			IconType mode;
+			if (tag == 7)
+				mode = IconType::kIconTypeSpecial;
+			else if (tag == 8)
+				mode = IconType::kIconTypeDeathEffect;
+			else
+				mode = static_cast<IconType>(tag);
+
+			this->setupPage(mode, page);
 		});
 		i1->setTag(i);
 		menu->addChild(i1);
@@ -322,14 +326,14 @@ void GarageLayer::setupPage(IconType type, int page)
 		auto browserItem = Sprite::createWithSpriteFrameName("playerSquare_001.png");
 		browserItem->setOpacity(0);
 
-		if (type == kIconTypeSpecial)
+		if (type == IconType::kIconTypeSpecial)
 		{
 			auto icono = Sprite::createWithSpriteFrameName(StringUtils::format("player_special_%02d_001.png", i));
 			icono->setPosition(browserItem->getContentSize() / 2);
 			icono->setScale(27.0f / icono->getContentSize().width);
 			browserItem->addChild(icono);
 		}
-		else if (type == kIconTypeDeathEffect)
+		else if (type == IconType::kIconTypeDeathEffect)
 		{
 			auto icono = Sprite::createWithSpriteFrameName(StringUtils::format("explosionIcon_%02d_001.png", i));
 			icono->setPosition(browserItem->getContentSize() / 2);
@@ -342,7 +346,7 @@ void GarageLayer::setupPage(IconType type, int page)
 			icono->updateGamemode(i, type);
 			icono->setMainColor({175, 175, 175});
 			icono->setPosition(browserItem->getContentSize() / 2);
-			if (type == kIconTypeUfo)
+			if (type == IconType::kIconTypeUfo)
 			{
 				icono->setPositionY(icono->getPositionY() + 5);
 				icono->m_pDomeSprite->setVisible(false);

--- a/Source/GarageLayer.h
+++ b/Source/GarageLayer.h
@@ -3,7 +3,7 @@
 
 #include "2d/CCScene.h"
 
-enum IconType;
+enum class IconType : int;
 class SimplePlayer;
 
 namespace ax 

--- a/Source/LevelBrowserLayer.cpp
+++ b/Source/LevelBrowserLayer.cpp
@@ -88,7 +88,7 @@ bool LevelBrowserLayer::init(GJSearchObject* search)
 			"http://www.boomlings.com/database/getGJLevels21.php", postData, ax::network::HttpRequest::Type::POST,
 			AX_CALLBACK_2(LevelBrowserLayer::onHttpRequestCompleted, this));
 	});
-	_rightBtn->setPosition({259.5, 0});
+	_rightBtn->setPosition(pageMenu->convertToNodeSpace(ax::Vec2(winSize.width - 24, winSize.height / 2)));
 	_leftBtn = MenuItemSpriteExtra::create("GJ_arrow_03_001.png", [this](Node*) {
 		_searchObj->_page--;
 		_leftBtn->setEnabled(false);
@@ -115,13 +115,12 @@ bool LevelBrowserLayer::init(GJSearchObject* search)
 	});
 	_leftBtn->setEnabled(false);
 	_leftBtn->setVisible(false);
-	_leftBtn->setPosition({-259.5, 0});
+	_leftBtn->setPosition(pageMenu->convertToNodeSpace(ax::Vec2(24, winSize.height / 2)));
 	_rightBtn->setScaleX(-1);
 	_rightBtn->setEnabled(false);
 	_rightBtn->setVisible(false);
 	pageMenu->addChild(_leftBtn);
 	pageMenu->addChild(_rightBtn);
-	pageMenu->setPosition({283.5, 160});
 	this->addChild(pageMenu, 5);
 
 	GameToolbox::createBG(this);

--- a/Source/LevelInfoLayer.cpp
+++ b/Source/LevelInfoLayer.cpp
@@ -19,6 +19,7 @@
 #include "2d/CCTransition.h"
 #include "CCEventListenerKeyboard.h"
 #include "network/HttpClient.h"
+#include "ccUTF8.h"
 
 USING_NS_AX;
 

--- a/Source/LoadingLayer.cpp
+++ b/Source/LoadingLayer.cpp
@@ -157,18 +157,18 @@ bool LoadingLayer::init() {
 	
 	auto robLogoSpr = Sprite::createWithSpriteFrameName("RobTopLogoBig_001.png");
 	robLogoSpr->setStretchEnabled(false);
-	robLogoSpr->setPosition({ 284.5f, 240.0f });
+	robLogoSpr->setPosition(logoSpr->getPosition() + Vec2(0, 80));
 	this->addChild(robLogoSpr);
 
 	auto splash = this->getSplash();
 	auto splashText = Label::createWithBMFont(GameToolbox::getTextureString("goldFont.fnt"), splash);
-	splashText->setPosition({ winSize.width / 2, 60.0f});
+	splashText->setPosition(winSize.width / 2, (winSize.height / 2) - 100);
 	splashText->setScale(0.7f);
 
 	this->addChild(splashText);
 	_pBar = SimpleProgressBar::create();
 	_pBar->setPercentage(0.f);
-	_pBar->setPosition({ winSize.width / 2, 100.0f });
+	_pBar->setPosition({ winSize.width / 2, splashText->getPosition().height + 40 });
 	this->addChild(_pBar);
 	
 	this->runAction(Sequence::create(DelayTime::create(0), CallFunc::create([&]() { this->loadAssets(); }), nullptr));

--- a/Source/NodeSerializer.cpp
+++ b/Source/NodeSerializer.cpp
@@ -100,10 +100,14 @@ void NodeSerializer::saveNodeToJsonFile(const std::string_view filename, ax::Nod
 	ax::FileUtils::getInstance()->writeStringToFile(j.dump(indentation), filename);
 }
 
+#if (AX_TARGET_PLATFORM == AX_PLATFORM_WIN32)
 #include <windows.h>
+#endif
+
 #include <string_view>
 
 static void CopyToClipboard(const std::string_view text) {
+#if (AX_TARGET_PLATFORM == AX_PLATFORM_WIN32)
 	// Open the clipboard
 	if (!OpenClipboard(nullptr)) {
 		// Handle error if clipboard cannot be opened
@@ -161,6 +165,7 @@ static void CopyToClipboard(const std::string_view text) {
 
 	// Close the clipboard
 	CloseClipboard();
+#endif
 }
 
 void NodeSerializer::copyNodeJsonToClipboard(ax::Node* node)

--- a/Source/PlayerObject.cpp
+++ b/Source/PlayerObject.cpp
@@ -7,6 +7,7 @@
 #include "2d/CCActionInstant.h"
 #include "2d/CCActionEase.h"
 #include "CircleWave.h"
+#include "ccUTF8.h"
 
 USING_NS_AX;
 

--- a/Source/ProfilePage.cpp
+++ b/Source/ProfilePage.cpp
@@ -233,31 +233,31 @@ void ProfilePage::loadPageFromUserInfo(GJUserScore* score) // replace with 'GJUs
 		switch(i)
 		{
 			case 0:
-				gamemode = kIconTypeCube;
+				gamemode = IconType::kIconTypeCube;
 				iconID = score->_accIcon;
 				break;
 			case 1:
-				gamemode = kIconTypeShip;
+				gamemode = IconType::kIconTypeShip;
 				iconID = score->_accShip;
 				break;
 			case 2:
-				gamemode = kIconTypeBall;
+				gamemode = IconType::kIconTypeBall;
 				iconID = score->_accBall;
 				break;
 			case 3:
-				gamemode = kIconTypeUfo;
+				gamemode = IconType::kIconTypeUfo;
 				iconID = score->_accBird;
 				break;
 			case 4:
-				gamemode = kIconTypeWave;
+				gamemode = IconType::kIconTypeWave;
 				iconID = score->_accDart;
 				break;
 			case 5:
-				gamemode = kIconTypeRobot;
+				gamemode = IconType::kIconTypeRobot;
 				iconID = score->_accRobot;
 				break;
 			case 6:
-				gamemode = kIconTypeSpider;
+				gamemode = IconType::kIconTypeSpider;
 				iconID = score->_accSpider;
 				break;
 		}

--- a/Source/SimplePlayer.cpp
+++ b/Source/SimplePlayer.cpp
@@ -8,7 +8,7 @@ USING_NS_AX;
 bool SimplePlayer::init(int cubeID) {
 	if (!Sprite::init()) return false;
 
-	this->updateGamemode(cubeID, kIconTypeCube);
+	this->updateGamemode(cubeID, IconType::kIconTypeCube);
 	this->setContentSize({ 60, 60 });
 	this->setAnchorPoint({.25f, .25f});
 
@@ -63,7 +63,7 @@ void SimplePlayer::updateGamemode(int iconID, IconType mode) {
 	}
 
 	// Dome
-	if (mode == kIconTypeUfo) {
+	if (mode == IconType::kIconTypeUfo) {
 		m_pDomeSprite = Sprite::createWithSpriteFrameName(domeFrame);
 		if (m_pDomeSprite) {
 			m_pDomeSprite->setPosition(this->m_pMainSprite->getContentSize() / 2);

--- a/Source/SimplePlayer.h
+++ b/Source/SimplePlayer.h
@@ -3,7 +3,7 @@
 #include "2d/CCSprite.h"
 #include "ccTypes.h"
 
-enum IconType;
+enum class IconType : int;
 
 class SimplePlayer : public ax::Sprite {
 public:

--- a/proj.android/app/.gitignore
+++ b/proj.android/app/.gitignore
@@ -1,2 +1,4 @@
+/assets
 /build
+/release
 /.externalNativeBuild

--- a/proj.android/app/AndroidManifest.xml
+++ b/proj.android/app/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="opengd"
+    package="com.opengdteam.opengd"
     android:installLocation="auto">
 
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/proj.android/app/build.gradle
+++ b/proj.android/app/build.gradle
@@ -14,7 +14,7 @@ android {
     def cmakeOptions = Eval.me(nbtInfo[3])
 
     defaultConfig {
-        applicationId "opengd"
+        applicationId "com.opengdteam.opengd"
         minSdkVersion PROP_MIN_SDK_VERSION
         targetSdkVersion PROP_TARGET_SDK_VERSION
         versionCode 1


### PR DESCRIPTION
This reverts the package name back to `com.opengdteam.opengd` due to the new one being invalid for not having at least one '.' (dot) character.

This fixes the issue with the forward declaration of IconType, which was causing compiler errors, by making it an enum class.

This replaces the usage of `std::ranges::find` with `std::find` in [GameObject::createFromString](https://github.com/Open-GD/OpenGD/blob/f26709b781ded904cde359456b9b483b67124dd6/Source/GameObject.cpp#L406) due to the former being unavailable in the latest release of the NDK (r25).

This fixes an issue with widescreen devices that causes the game to be "more zoomed in".